### PR TITLE
feat: capture raw watch sensor data for sleep staging

### DIFF
--- a/wearos/app/src/main/AndroidManifest.xml
+++ b/wearos/app/src/main/AndroidManifest.xml
@@ -49,6 +49,12 @@
             android:exported="false"
             android:foregroundServiceType="health" />
 
+        <!-- Sleep capture foreground service (HR + accel → 30s feature batches → phone) -->
+        <service
+            android:name=".sleep.SleepCaptureService"
+            android:exported="false"
+            android:foregroundServiceType="health" />
+
         <!-- TODO: Wear Tile Service (implement when Tiles Material 3 is integrated) -->
 
         <!-- Standalone Wear OS app (no phone companion required) -->

--- a/wearos/app/src/main/java/com/seren/watch/health/HealthServicesManager.kt
+++ b/wearos/app/src/main/java/com/seren/watch/health/HealthServicesManager.kt
@@ -1,6 +1,10 @@
 package com.seren.watch.health
 
 import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
 import android.util.Log
 import androidx.health.services.client.HealthServices
 import androidx.health.services.client.MeasureCallback
@@ -23,6 +27,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.Executors
+import kotlin.math.sqrt
 
 /**
  * Manages Health Services API on the watch.
@@ -38,6 +43,8 @@ class HealthServicesManager(private val context: Context) {
     private val measureClient: MeasureClient = healthClient.measureClient
     private val passiveClient: PassiveMonitoringClient = healthClient.passiveMonitoringClient
     private val executor = Executors.newSingleThreadExecutor()
+    private val sensorManager: SensorManager =
+        context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
 
     private val _wellnessState = MutableStateFlow(WellnessState())
     val wellnessState: StateFlow<WellnessState> = _wellnessState.asStateFlow()
@@ -118,6 +125,42 @@ class HealthServicesManager(private val context: Context) {
             Log.d(TAG, "Passive monitoring started")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start passive monitoring", e)
+        }
+    }
+
+    /**
+     * Accelerometer magnitude stream (gravity-included Euclidean norm, g units).
+     * Matches `acc_magnitude` in ml/sleep/prepare_features.py — sqrt(ax² + ay² + az²)
+     * where each axis is in m/s² normalized to g (÷ 9.80665).
+     *
+     * Sampling rate is requested at ~25 Hz (SENSOR_DELAY_GAME → 20 ms target).
+     * Each emission carries (timestampMs, magnitudeG).
+     */
+    fun accelerometerFlow(): Flow<AccelSample> = callbackFlow {
+        val accel = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+        if (accel == null) {
+            Log.w(TAG, "No TYPE_ACCELEROMETER sensor on this device")
+            close()
+            return@callbackFlow
+        }
+        val listener = object : SensorEventListener {
+            override fun onSensorChanged(event: SensorEvent) {
+                val ax = event.values[0] / 9.80665f
+                val ay = event.values[1] / 9.80665f
+                val az = event.values[2] / 9.80665f
+                val mag = sqrt(ax * ax + ay * ay + az * az)
+                // Convert event.timestamp (nanos since boot) → epoch ms.
+                val deltaNanos = event.timestamp - System.nanoTime()
+                val tsMs = System.currentTimeMillis() + deltaNanos / 1_000_000L
+                trySend(AccelSample(tsMs, mag))
+            }
+            override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+        }
+        sensorManager.registerListener(listener, accel, SensorManager.SENSOR_DELAY_GAME)
+        Log.d(TAG, "Accel capture started @ SENSOR_DELAY_GAME (~25 Hz)")
+        awaitClose {
+            sensorManager.unregisterListener(listener)
+            Log.d(TAG, "Accel capture stopped")
         }
     }
 

--- a/wearos/app/src/main/java/com/seren/watch/health/SensorSamples.kt
+++ b/wearos/app/src/main/java/com/seren/watch/health/SensorSamples.kt
@@ -1,0 +1,19 @@
+package com.seren.watch.health
+
+/** Raw heart-rate sample emitted by HealthServicesManager.heartRateFlow(). */
+data class HrSample(
+    /** Unix epoch milliseconds. */
+    val timestampMs: Long,
+    /** Beats per minute. */
+    val bpm: Int,
+)
+
+/**
+ * Raw accelerometer magnitude sample emitted by HealthServicesManager.accelerometerFlow().
+ * `magnitudeG` is sqrt(ax² + ay² + az²) in g units, **including gravity** (~1g at rest).
+ * This matches `acc_magnitude` in ml/sleep/prepare_features.py.
+ */
+data class AccelSample(
+    val timestampMs: Long,
+    val magnitudeG: Float,
+)

--- a/wearos/app/src/main/java/com/seren/watch/sleep/EpochAggregator.kt
+++ b/wearos/app/src/main/java/com/seren/watch/sleep/EpochAggregator.kt
@@ -1,0 +1,165 @@
+package com.seren.watch.sleep
+
+import com.seren.watch.health.AccelSample
+import com.seren.watch.health.HrSample
+
+/**
+ * Aligned 30-second sleep epoch.
+ *
+ * `features` holds the 11 cache features in the order:
+ *   hr_mean, hr_std, hr_min, hr_max, hr_range,
+ *   hr_succdiff_std, hr_delta_prev,
+ *   act_count, immobility_frac, act_max, act_std
+ *
+ * The 12th feature (time_of_night) is appended on the phone once the
+ * full night is known. Do NOT add it here.
+ */
+data class RawEpochFeatures(
+    /** Epoch start time, Unix ms. */
+    val startMs: Long,
+    /** Length 11. */
+    val features: FloatArray,
+) {
+    companion object {
+        const val SIZE = 11
+    }
+}
+
+/**
+ * Rolling 30-s epoch aggregator. Buffers raw HR and accel samples and emits
+ * a [RawEpochFeatures] every time an epoch boundary is crossed.
+ *
+ * Mirrors the Python feature extraction in ml/sleep/prepare_features.py exactly:
+ *   - HR features use a ±120-s window centred on the epoch midpoint
+ *   - Accel features use only the in-epoch samples (start..start+30s)
+ *   - acc_count / immob / act_max use abs-diff of magnitude; act_std uses raw magnitude std
+ *
+ * Thread-safety: not safe for concurrent calls. Drive from a single coroutine.
+ */
+class EpochAggregator(
+    /** Absolute Unix ms at which capture began (used to align epoch boundaries). */
+    captureStartMs: Long,
+) {
+    private val epochStartMs: Long = (captureStartMs / EPOCH_MS) * EPOCH_MS
+    private var nextEpochIndex: Int = 0
+
+    // Hold a generous trailing buffer so HR's ±120 s window is always satisfied.
+    private val hrBuffer: ArrayDeque<HrSample> = ArrayDeque()
+    private val accBuffer: ArrayDeque<AccelSample> = ArrayDeque()
+
+    // Track previous epoch's hr_mean for hr_delta_prev.
+    private var prevHrMean: Double? = null
+
+    fun addHr(sample: HrSample) {
+        hrBuffer.addLast(sample)
+        // Trim: HR needs ±HR_WIN_MS of context, so only drop samples older than
+        // (currentEpochCentre - HR_WIN_MS - EPOCH_MS) — be generous.
+        val keepAfter = epochStartFor(nextEpochIndex) - HR_WIN_MS - EPOCH_MS
+        while (hrBuffer.isNotEmpty() && hrBuffer.first().timestampMs < keepAfter) {
+            hrBuffer.removeFirst()
+        }
+    }
+
+    fun addAccel(sample: AccelSample) {
+        accBuffer.addLast(sample)
+        val keepAfter = epochStartFor(nextEpochIndex) - EPOCH_MS
+        while (accBuffer.isNotEmpty() && accBuffer.first().timestampMs < keepAfter) {
+            accBuffer.removeFirst()
+        }
+    }
+
+    /**
+     * Try to emit completed epochs. Returns 0..N epochs whose right edge has
+     * passed (with a small safety margin for HR's forward window).
+     */
+    fun drainCompleted(nowMs: Long): List<RawEpochFeatures> {
+        val emitted = mutableListOf<RawEpochFeatures>()
+        while (true) {
+            val et = epochStartFor(nextEpochIndex)
+            // HR needs samples up to et + EPOCH_MS/2 + HR_WIN_MS.
+            // We require that we've seen past that point before closing the epoch.
+            val readyAt = et + EPOCH_MS / 2 + HR_WIN_MS
+            if (nowMs < readyAt) break
+
+            val features = extract(et)
+            if (features != null) {
+                emitted.add(RawEpochFeatures(et, features))
+            }
+            nextEpochIndex++
+        }
+        return emitted
+    }
+
+    private fun epochStartFor(index: Int): Long = epochStartMs + index.toLong() * EPOCH_MS
+
+    /**
+     * Returns the 11-feature vector for the epoch beginning at `et`, or null
+     * if there is no HR data in the window (drop epoch, reset prevHrMean).
+     */
+    private fun extract(et: Long): FloatArray? {
+        val centre = et + EPOCH_MS / 2
+        // HR ±120 s
+        val hrSeg = hrBuffer.asSequence()
+            .filter { it.timestampMs in (centre - HR_WIN_MS) until (centre + HR_WIN_MS) }
+            .map { it.bpm.toDouble() }
+            .toList()
+        if (hrSeg.isEmpty()) {
+            prevHrMean = null
+            return null
+        }
+        // Accel: in-epoch only
+        val accSeg = accBuffer.asSequence()
+            .filter { it.timestampMs in et until (et + EPOCH_MS) }
+            .map { it.magnitudeG.toDouble() }
+            .toList()
+
+        val hrMean = hrSeg.average()
+        val hrStd = if (hrSeg.size > 1) populationStd(hrSeg) else 0.0
+        val hrMin = hrSeg.min()
+        val hrMax = hrSeg.max()
+        val hrRng = hrMax - hrMin
+        val hrSdsd = if (hrSeg.size > 2) populationStd(diffs(hrSeg)) else 0.0
+        val hrDlt = prevHrMean?.let { hrMean - it } ?: 0.0
+
+        val (actCount, immob, actMax, actStd) = if (accSeg.size > 1) {
+            val d = diffs(accSeg).map { kotlin.math.abs(it) }
+            val count = d.sum()
+            val frac = d.count { it < MOVE_THRESH_G } / d.size.toDouble()
+            val max = d.max()
+            val std = populationStd(accSeg)
+            FourDoubles(count, frac, max, std)
+        } else {
+            FourDoubles(0.0, 0.0, 0.0, 0.0)
+        }
+
+        prevHrMean = hrMean
+        return floatArrayOf(
+            hrMean.toFloat(), hrStd.toFloat(), hrMin.toFloat(), hrMax.toFloat(), hrRng.toFloat(),
+            hrSdsd.toFloat(), hrDlt.toFloat(),
+            actCount.toFloat(), immob.toFloat(), actMax.toFloat(), actStd.toFloat(),
+        )
+    }
+
+    private data class FourDoubles(val a: Double, val b: Double, val c: Double, val d: Double)
+
+    companion object {
+        const val EPOCH_MS: Long = 30_000L
+        const val HR_WIN_MS: Long = 120_000L
+        const val MOVE_THRESH_G: Double = 0.02
+    }
+}
+
+// ── Numeric helpers ───────────────────────────────────────────────
+// Population std (ddof=0) to match NumPy's default np.std.
+private fun populationStd(xs: List<Double>): Double {
+    val m = xs.average()
+    var s = 0.0
+    for (x in xs) s += (x - m) * (x - m)
+    return kotlin.math.sqrt(s / xs.size)
+}
+
+private fun diffs(xs: List<Double>): List<Double> {
+    val out = ArrayList<Double>(xs.size - 1)
+    for (i in 1 until xs.size) out.add(xs[i] - xs[i - 1])
+    return out
+}

--- a/wearos/app/src/main/java/com/seren/watch/sleep/SleepCaptureService.kt
+++ b/wearos/app/src/main/java/com/seren/watch/sleep/SleepCaptureService.kt
@@ -1,0 +1,157 @@
+package com.seren.watch.sleep
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.seren.watch.health.HealthServicesManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+/**
+ * Foreground service that runs while the user is sleeping. Pumps HR + accel
+ * samples into an EpochAggregator, batches completed epochs, and ships them
+ * to the phone every BATCH_INTERVAL_MS. On stop, flushes a final batch with
+ * the "finalize" marker so the phone runs inference and clears state.
+ *
+ * Start:  startForegroundService(Intent(ctx, SleepCaptureService::class.java).setAction(ACTION_START))
+ * Stop:   startService(Intent(ctx, SleepCaptureService::class.java).setAction(ACTION_STOP))
+ */
+class SleepCaptureService : Service() {
+
+    companion object {
+        private const val TAG = "SerenSleepSvc"
+        const val ACTION_START = "com.seren.watch.sleep.START"
+        const val ACTION_STOP = "com.seren.watch.sleep.STOP"
+        const val CHANNEL_ID = "seren_sleep_capture"
+        const val NOTIFICATION_ID = 2001
+
+        /** How often to flush completed epochs to the phone. */
+        private const val BATCH_INTERVAL_MS: Long = 10 * 60 * 1000L
+        /** Sweep cadence for draining the aggregator (must be < BATCH_INTERVAL_MS). */
+        private const val SWEEP_INTERVAL_MS: Long = 30_000L
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var captureJob: Job? = null
+    private lateinit var health: HealthServicesManager
+    private lateinit var sender: WearableFeatureSender
+    private lateinit var aggregator: EpochAggregator
+    private var captureStartMs: Long = 0L
+    private val pending = ArrayDeque<RawEpochFeatures>()
+    private var lastFlushMs: Long = 0L
+
+    override fun onCreate() {
+        super.onCreate()
+        health = HealthServicesManager(applicationContext)
+        sender = WearableFeatureSender(applicationContext)
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_STOP -> {
+                stopCapture()
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                stopSelf()
+                return START_NOT_STICKY
+            }
+            else -> {
+                startForeground(NOTIFICATION_ID, buildNotification())
+                startCapture()
+            }
+        }
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun startCapture() {
+        if (captureJob?.isActive == true) return
+        captureStartMs = System.currentTimeMillis()
+        lastFlushMs = captureStartMs
+        aggregator = EpochAggregator(captureStartMs)
+        pending.clear()
+
+        captureJob = scope.launch {
+            // HR pump
+            val hrJob = launch {
+                health.heartRateFlow().collect { bpm ->
+                    aggregator.addHr(com.seren.watch.health.HrSample(System.currentTimeMillis(), bpm))
+                }
+            }
+            // Accel pump
+            val accJob = launch {
+                health.accelerometerFlow().collect { sample ->
+                    aggregator.addAccel(sample)
+                }
+            }
+            // Sweep + batch loop. Cancellation propagates from stopCapture()
+            // via the scope cancel; the child collectors above stop with it.
+            try {
+                while (true) {
+                    delay(SWEEP_INTERVAL_MS)
+                    val now = System.currentTimeMillis()
+                    val completed = aggregator.drainCompleted(now)
+                    if (completed.isNotEmpty()) pending.addAll(completed)
+                    if (pending.isNotEmpty() && now - lastFlushMs >= BATCH_INTERVAL_MS) {
+                        val batch = pending.toList()
+                        pending.clear()
+                        sender.send(captureStartMs, batch, final = false)
+                        lastFlushMs = now
+                    }
+                }
+            } finally {
+                hrJob.cancel()
+                accJob.cancel()
+            }
+        }
+        Log.d(TAG, "Sleep capture started at $captureStartMs")
+    }
+
+    private fun stopCapture() {
+        val now = System.currentTimeMillis()
+        // Final flush: include anything still in the aggregator.
+        val final = (pending + aggregator.drainCompleted(now + EpochAggregator.HR_WIN_MS)).toList()
+        pending.clear()
+        scope.launch { sender.send(captureStartMs, final, final = true) }
+        captureJob?.cancel()
+        captureJob = null
+        Log.d(TAG, "Sleep capture stopped; final batch ${final.size} epochs queued")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Sleep tracking",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply { description = "Captures HR + motion for nightly sleep staging" }
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(): Notification {
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Seren sleep tracking")
+            .setContentText("Capturing your sleep")
+            .setSmallIcon(android.R.drawable.ic_menu_compass)
+            .setOngoing(true)
+            .build()
+    }
+}

--- a/wearos/app/src/main/java/com/seren/watch/sleep/WearableFeatureSender.kt
+++ b/wearos/app/src/main/java/com/seren/watch/sleep/WearableFeatureSender.kt
@@ -1,0 +1,76 @@
+package com.seren.watch.sleep
+
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.tasks.await
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Ships completed sleep epochs from the watch to the phone over the Wearable
+ * Data Layer (MessageClient).
+ *
+ * Wire format (little-endian, version 1):
+ *   header  : magic 'SRN1' (4 bytes), version u16, reserved u16
+ *   metadata: captureStartMs i64, epochCount u32, featuresPerEpoch u16, reserved u16
+ *   payload : epochCount × (startMs i64 + 11 × float32)
+ *
+ * Total bytes per epoch = 8 + 11*4 = 52.  A 9-hour night ≈ 1080 epochs ≈ 56 KB.
+ *
+ * Message path:
+ *   /seren/sleep/features/batch     — incremental batches during the night
+ *   /seren/sleep/features/finalize  — last batch + "session ended" signal
+ */
+class WearableFeatureSender(private val context: Context) {
+
+    companion object {
+        private const val TAG = "SerenSleep"
+        const val MAGIC: Int = 0x314E5253 // 'SRN1' little-endian
+        const val VERSION: Short = 1
+        const val PATH_BATCH = "/seren/sleep/features/batch"
+        const val PATH_FINALIZE = "/seren/sleep/features/finalize"
+    }
+
+    private val messageClient = Wearable.getMessageClient(context)
+    private val nodeClient = Wearable.getNodeClient(context)
+
+    /** Sends `epochs` to every connected node. Use [final] = true at session end. */
+    suspend fun send(captureStartMs: Long, epochs: List<RawEpochFeatures>, final: Boolean) {
+        if (epochs.isEmpty() && !final) return
+        val payload = encode(captureStartMs, epochs)
+        val path = if (final) PATH_FINALIZE else PATH_BATCH
+        try {
+            val nodes = nodeClient.connectedNodes.await()
+            if (nodes.isEmpty()) {
+                Log.w(TAG, "No paired nodes; ${epochs.size} epochs not delivered")
+                return
+            }
+            for (node in nodes) {
+                messageClient.sendMessage(node.id, path, payload).await()
+            }
+            Log.d(TAG, "Sent ${epochs.size} epochs (final=$final) to ${nodes.size} node(s)")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to send epoch batch", e)
+        }
+    }
+
+    private fun encode(captureStartMs: Long, epochs: List<RawEpochFeatures>): ByteArray {
+        val headerSize = 4 + 2 + 2 + 8 + 4 + 2 + 2
+        val epochSize = 8 + RawEpochFeatures.SIZE * 4
+        val buf = ByteBuffer.allocate(headerSize + epochs.size * epochSize)
+            .order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(MAGIC)
+        buf.putShort(VERSION)
+        buf.putShort(0)
+        buf.putLong(captureStartMs)
+        buf.putInt(epochs.size)
+        buf.putShort(RawEpochFeatures.SIZE.toShort())
+        buf.putShort(0)
+        for (e in epochs) {
+            buf.putLong(e.startMs)
+            for (v in e.features) buf.putFloat(v)
+        }
+        return buf.array()
+    }
+}


### PR DESCRIPTION
Adds raw sensor capture on the Wear OS companion to feed the sleep-stage model.

## What's included
- SensorSamples.kt and sleep/ services (SleepCaptureService, EpochAggregator, WearableFeatureSender)
- Collects accelerometer/heart-rate epochs on the watch and sends features to the phone
- Extends HealthServicesManager and adds the required sensor permissions to AndroidManifest

Rebased onto latest main; no conflicts.