### PR TITLE
security: remove hardcoded DB credential + CSPRNG tokens (gap I1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Seren — environment template. Copy to `.env` and fill in. `.env` is git-ignored.
+#
+# IMPORTANT: Expo inlines every EXPO_PUBLIC_* var into the CLIENT bundle. Only put
+# values here that are safe to ship to clients, or move them server-side. Health data
+# stays on-device; only auth + (optional) LLM/observability keys live here.
+
+# --- Neon Postgres (auth) ---
+# WARNING: a direct client -> Postgres connection exposes this credential in the bundle.
+# The mature fix is a server-side API or Supabase RLS so the secret never reaches the
+# client. If this value was ever committed to git, ROTATE it in the Neon console.
+EXPO_PUBLIC_DATABASE_URL=postgresql://USER:PASSWORD@HOST/DB?sslmode=require
+
+# --- Supabase (alternative auth provider; anon key is safe to expose with RLS on) ---
+EXPO_PUBLIC_SUPABASE_URL=https://YOUR-PROJECT.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+
+# --- LLM providers (voice check-in analysis) ---
+EXPO_PUBLIC_OPENROUTER_API_KEY=your-openrouter-key
+EXPO_PUBLIC_GROQ_API_KEY=your-groq-key
+
+# --- Observability (optional, gap I2) ---
+# EXPO_PUBLIC_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0

--- a/template/auth/neon/service.ts
+++ b/template/auth/neon/service.ts
@@ -4,9 +4,14 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Crypto from 'expo-crypto';
 import { AuthUser, SendOTPOptions } from '../types';
 
-// WARNING: In production, move this to a server-side API and do not expose DB credentials in the client bundle.
-const DATABASE_URL =
-  'postgresql://neondb_owner:npg_iLGRXxrD7tl5@ep-frosty-mode-amkt0rpn-pooler.c-5.us-east-1.aws.neon.tech/neondb?sslmode=require';
+// Connection string comes from the environment (see .env.example) — credentials must
+// NOT be hardcoded. NOTE: Expo inlines EXPO_PUBLIC_* into the client bundle, so a direct
+// client -> Postgres connection still ships this secret. The production-grade fix is a
+// server-side API or Supabase RLS so the credential never reaches the client.
+const DATABASE_URL = process.env.EXPO_PUBLIC_DATABASE_URL ?? '';
+if (!DATABASE_URL) {
+  console.warn('[Seren] EXPO_PUBLIC_DATABASE_URL is not set — copy .env.example to .env; auth will fail until it is set.');
+}
 
 const sql = neon(DATABASE_URL);
 
@@ -66,7 +71,9 @@ function mapRow(row: any): AuthUser {
 }
 
 async function createSession(userId: string): Promise<void> {
-  const token = `seren_${Date.now()}_${Math.random().toString(36).slice(2, 18)}`;
+  // Cryptographically-secure session token (Date.now()+Math.random() is guessable).
+  const rand = await Crypto.getRandomBytesAsync(24);
+  const token = 'seren_' + Array.from(rand, (b) => b.toString(16).padStart(2, '0')).join('');
   const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 
   await sql`


### PR DESCRIPTION
Addresses maturity gap **I1** (partial — see note).

- Moves the Neon connection string out of source into `EXPO_PUBLIC_DATABASE_URL` — **no DB credential in the repo** anymore.
- Session tokens now use `expo-crypto` `getRandomBytesAsync` instead of `Date.now()+Math.random()` (guessable).
- Adds `.env.example` documenting every required key (also gap I6).

## ⚠️ Before merging
1. **Rotate the Neon credential** — the old one is in git history, so it's compromised.
2. Put the new connection string in your local `.env` as `EXPO_PUBLIC_DATABASE_URL=...` (and in any CI/Kaggle secret store that needs it).
3. Then merge — merging before `.env` is set will break login.

## Architectural note (not fixed here)
Expo inlines `EXPO_PUBLIC_*` into the client bundle, so a direct client→Postgres connection still exposes the credential. The production-grade fix is a server-side API or **Supabase Auth + RLS** (the repo already has a Supabase template). Recommend tracking that as a follow-up.

Not auto-merged — needs the credential rotation + `.env` first, and it touches the shared auth template.