### PR TITLE
fix: bundle .onnx as a Metro asset so the sleep model loads

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,12 @@
+// Learn more: https://docs.expo.dev/guides/customizing-metro/
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+// Bundle the on-device sleep model as an asset so
+// `require('@/assets/ml/sleep/sleep_stage_model.onnx')` resolves.
+if (!config.resolver.assetExts.includes('onnx')) {
+  config.resolver.assetExts.push('onnx');
+}
+
+module.exports = config;


### PR DESCRIPTION
Without a `metro.config.js`, Expo's default `assetExts` excludes `.onnx`, so `require('@/assets/ml/sleep/sleep_stage_model.onnx')` threw *Cannot find module* and the on-device sleep model never loaded (silently fell back to Health Connect stages). Adds a metro config that pushes `onnx` onto `resolver.assetExts`. Requires a clean Metro restart (`expo start -c`).