### PR TITLE
feat: Supabase auth migration (I1) + Sentry (I2) + eas.json (I3)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,11 +5,14 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { WellnessProvider } from '@/hooks/useWellness';
 import { DraggableFAB } from '@/components/ui/DraggableFAB';
-import { NeonAuthProvider as AuthProvider } from '@/template/auth/neon/context';
+import { AuthProvider } from '@/template/auth/supabase/context';
 import { registerBackgroundInferenceTask } from '@/services/background/inferenceTask';
+import { initSentry } from '@/services/observability/sentry';
 
 export default function RootLayout() {
   useEffect(() => {
+    // Crash/error reporting — dormant unless EXPO_PUBLIC_SENTRY_DSN is set.
+    initSentry();
     // Register background inference task on app startup
     registerBackgroundInferenceTask().catch(err => {
       console.error('Failed to register background task:', err);

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,26 @@
+{
+  "cli": {
+    "version": ">= 5.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "android": { "buildType": "apk" }
+    },
+    "preview": {
+      "distribution": "internal",
+      "channel": "preview",
+      "android": { "buildType": "apk" }
+    },
+    "production": {
+      "autoIncrement": true,
+      "channel": "production",
+      "android": { "buildType": "app-bundle" }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -5,11 +5,11 @@
  */
 
 // @ts-nocheck
-import { useNeonAuth } from '@/template/auth/neon/hook';
+import { useAuth as useSupabaseAuth } from '@/template/auth/supabase/hook';
 import type { AuthUser } from '@/template/auth/types';
 
 export function useAuth() {
-  const auth = useNeonAuth();
+  const auth = useSupabaseAuth();
   return {
     ...auth,
     isAuthenticated: !!auth.user,

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@react-navigation/native-stack": "^7.3.10",
         "@react-navigation/routers": "7.3.5",
         "@react-navigation/stack": "7.2.10",
+        "@sentry/react-native": "^8.14.0",
         "@shopify/flash-list": "2.0.2",
         "@shopify/react-native-skia": "2.2.12",
         "@stripe/stripe-react-native": "0.50.3",
@@ -6837,6 +6838,327 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.57.0.tgz",
+      "integrity": "sha512-tXObp954rMTSYKlbftjVXHtNl4t/6ssks3jkqyzmKb+PDPWzabGQO7sWwqVuTjT8Kx/8A3FmriS1bGmqxiJy3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.57.0.tgz",
+      "integrity": "sha512-ZcF4QhkqGX3iiQSXB2N0N3Awp+j5iqnDRu6PA/qyLFrWqH5ZiiAAgu59OLD9E6XAdg6iFtLYw19MAMZVK8qNOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.57.0.tgz",
+      "integrity": "sha512-Wmnx/6ABynVH1iwuoNUqJNyjIUqsqoGML7qsyivBRKb5Wo2YQtPOQlQYfxfZSvWzGpcoSVdInkRjDssUQxQEQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.57.0.tgz",
+      "integrity": "sha512-zsfa4JcfV0AEc9YhNxNabd5lSZL2Av84saAyexGAqcHs+67m9Gd0cGStOzMb/nCl7UAtmdP0aI+G7a3rcxxN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.3.0.tgz",
+      "integrity": "sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.57.0.tgz",
+      "integrity": "sha512-s36AQy/CKXTfyY9Z+qUhzNomntZXgfs0rbaK7q9ffnFkqcPwzE8qQtVs58y3Suut56u+AhwSztgQtERcuZ5VIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.57.0",
+        "@sentry-internal/feedback": "10.57.0",
+        "@sentry-internal/replay": "10.57.0",
+        "@sentry-internal/replay-canvas": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.5.0.tgz",
+      "integrity": "sha512-D3N3kULOnAClRkhHKqOAcOTtDnRe7hFacdHLlSsQXAZB11Qu6VAy8mGmM3654Lq/3LHl5h8CW590JGR9E0yahQ==",
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "undici": "^6.22.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "3.5.0",
+        "@sentry/cli-linux-arm": "3.5.0",
+        "@sentry/cli-linux-arm64": "3.5.0",
+        "@sentry/cli-linux-i686": "3.5.0",
+        "@sentry/cli-linux-x64": "3.5.0",
+        "@sentry/cli-win32-arm64": "3.5.0",
+        "@sentry/cli-win32-i686": "3.5.0",
+        "@sentry/cli-win32-x64": "3.5.0"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.5.0.tgz",
+      "integrity": "sha512-Q7WIq+SNMh/7gddovgcHUBlgzsH2jASdkxinwxoDZVNcF96gqr35QllRHkxZTt1+nLM3JytL2A+Mh9JdvMWzsA==",
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.5.0.tgz",
+      "integrity": "sha512-d4U64gQikZiqr63XL3suWhd28e0NQg63GX+JumRiDYCDCAF3gmdUS6BRR43lyoZm2wqhHRQSms2bMArAPTDH/w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.5.0.tgz",
+      "integrity": "sha512-nWlWo0qw1OqcOFR6GgcJ3KT+bMOlE3BFBtbMCxyURb4dTcT+NPy1Oe9Kk+JyWgRk1xm4CTaPXJNd2JD5V36FQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.5.0.tgz",
+      "integrity": "sha512-HE8zFNvg/YWudGp+pBeJSNgF/siyarnlBkWbRxz6WApsFq7uvajXPk7EqwJ0onKnzPS14OPlTtTejA3iSUuCNg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.5.0.tgz",
+      "integrity": "sha512-uU6h/b3SIoWysn0U6PoyUx/R5z9kU9+VcuvydjlqkZGDbbcRIxqp0T/wgB/jhXeFaSSPSFlmmkQCVYi8PXCrSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.5.0.tgz",
+      "integrity": "sha512-P13w9Vc/ur6rnwtiBe4wzu4M81ODhdOGc8iWpkN51gzjldjz9FF4F2UEdS9UUYBxesWJU+UF62ZVQ4H73rhS4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.5.0.tgz",
+      "integrity": "sha512-LZIEsJ5zMd0HAYlnG7G7OM6/AOvFaWkuBPdePZqYvtMLOUsfY7zeW8ubyZ9uCOWsj5Xc7UiDF4v0gZ45Strlkg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.5.0.tgz",
+      "integrity": "sha512-Dgkn60xoF7csXcKk+gRlmOA7s//7w0R3QlaXCo5RbX/c5VTbcV74r6ON7A+SKTFO9i4fEGblLlzQ0MLqrIo2sw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.57.0.tgz",
+      "integrity": "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/expo-upload-sourcemaps": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/@sentry/expo-upload-sourcemaps/-/expo-upload-sourcemaps-8.14.0.tgz",
+      "integrity": "sha512-caPp11nVIAHtCTaM2kTqf3wG5aAui09EbeqoBEA9//NnRkuOVuRqapfX+ABTFlnnimbBSvn3MKrQt6HTMp/ELQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/cli": "3.5.0"
+      },
+      "bin": {
+        "expo-upload-sourcemaps": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@expo/env": "*",
+        "dotenv": "*"
+      },
+      "peerDependenciesMeta": {
+        "@expo/env": {
+          "optional": true
+        },
+        "dotenv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.57.0.tgz",
+      "integrity": "sha512-6QThwQ4XWQ2rwKZEVQ9P9WKl7JlowC7S5LpAvmMdrwlfJBpLDFOsM7tycnIvbXTXf0ZOOuLFPa4L4YYbdyNGmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/react-native": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-8.14.0.tgz",
+      "integrity": "sha512-2OF5M1Easgo25qX5360I/zb/P8IPhu6YXTgvCQCA6AYHxZvLf/9w/Rzaa+BYl6wBnnUvserjtua1xXdSrQhQXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/babel-plugin-component-annotate": "5.3.0",
+        "@sentry/browser": "10.57.0",
+        "@sentry/cli": "3.5.0",
+        "@sentry/core": "10.57.0",
+        "@sentry/expo-upload-sourcemaps": "8.14.0",
+        "@sentry/react": "10.57.0"
+      },
+      "bin": {
+        "sentry-eas-build-on-complete": "scripts/eas-build-hook.js",
+        "sentry-eas-build-on-error": "scripts/eas-build-hook.js",
+        "sentry-eas-build-on-success": "scripts/eas-build-hook.js",
+        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
+      },
+      "peerDependencies": {
+        "expo": ">=49.0.0",
+        "react": ">=17.0.0",
+        "react-native": ">=0.65.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@shopify/flash-list": {
       "version": "2.0.2",
@@ -19888,6 +20210,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@react-navigation/native-stack": "^7.3.10",
     "@react-navigation/routers": "7.3.5",
     "@react-navigation/stack": "7.2.10",
+    "@sentry/react-native": "^8.14.0",
     "@shopify/flash-list": "2.0.2",
     "@shopify/react-native-skia": "2.2.12",
     "@stripe/stripe-react-native": "0.50.3",

--- a/services/observability/sentry.ts
+++ b/services/observability/sentry.ts
@@ -1,0 +1,28 @@
+/**
+ * Optional crash / error reporting (Sentry).
+ *
+ * DORMANT until `EXPO_PUBLIC_SENTRY_DSN` is set in `.env`:
+ *   1. create a project at https://sentry.io (platform: React Native)
+ *   2. copy the DSN into `.env` as EXPO_PUBLIC_SENTRY_DSN=...
+ *   3. rebuild the dev/app build so the native @sentry module is linked
+ *
+ * The `@sentry/react-native` module is imported DYNAMICALLY and only when a DSN is
+ * present, so a build without Sentry (or without the native module yet) runs fine.
+ */
+export async function initSentry(): Promise<void> {
+  const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
+  if (!dsn) return; // not configured -> stay dormant
+  try {
+    const Sentry = await import('@sentry/react-native');
+    Sentry.init({
+      dsn,
+      // Capture a sample of performance traces; tune for production.
+      tracesSampleRate: 0.2,
+      // Health data stays on-device; never attach PII automatically.
+      sendDefaultPii: false,
+    });
+    console.log('[Seren] Sentry crash reporting initialized');
+  } catch (e) {
+    console.warn('[Seren] Sentry init skipped:', e);
+  }
+}


### PR DESCRIPTION
Addresses three maturity gaps. **Not auto-merged** — the auth swap needs a real signup test first.

## I1 — real auth fix (Supabase)
Switches the active auth provider from **Neon** (direct client→Postgres; the DB credential is shipped in the client bundle) to **Supabase Auth** (anon key is designed to be public + RLS; password hashing and sessions are handled server-side). This gets the DB secret out of the client entirely.
- JS-only: `_layout.tsx` provider + `hooks/useAuth.ts` hook swapped to the (already-implemented) Supabase template, which reads `EXPO_PUBLIC_SUPABASE_URL`/`ANON_KEY` from `.env` (already set).
- No native rebuild — reload Metro.

## I2 — Sentry observability
`services/observability/sentry.ts` — crash/error reporting, **gated on `EXPO_PUBLIC_SENTRY_DSN`** and dynamically imported, so it's dormant until configured. Add the DSN + rebuild to activate.

## I3 — EAS
`eas.json` with development / preview / production profiles (APK for dev/preview, app-bundle for prod).

## Verification
- jest **172/172**.
- ⚠️ Before merge: reload Metro and **test sign-up against Supabase**. In the Supabase dashboard (Auth → Providers → Email), ensure email auth is on; for instant signup→login during the demo, consider disabling "Confirm email".