### PR TITLE
feat: per-subject on-device normalization for stress (gap S1)

### DIFF
--- a/__tests__/perUserNorm.test.ts
+++ b/__tests__/perUserNorm.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests — per-user (per-subject) normalization (gap S1).
+ */
+import { computePerUserNorm } from '@/services/ai/perUserNorm';
+import type { BiometricFeatureVector } from '@/services/ai/types';
+
+function fv(rmssd: number, hrMean: number): BiometricFeatureVector {
+  // Only the fields under test need to be present for these unit tests.
+  return { rmssd, hrMean } as unknown as BiometricFeatureVector;
+}
+
+describe('computePerUserNorm', () => {
+  test('returns null below minSamples (cold-start -> caller uses global)', () => {
+    const windows = Array.from({ length: 10 }, () => fv(40, 70));
+    expect(computePerUserNorm(windows, ['rmssd', 'hrMean'], 30)).toBeNull();
+    expect(computePerUserNorm(null, ['rmssd'], 30)).toBeNull();
+    expect(computePerUserNorm([], ['rmssd'], 30)).toBeNull();
+  });
+
+  test('computes per-feature mean/std at/above minSamples', () => {
+    // rmssd = 10,20,30 repeated -> mean 20; hrMean constant 60 -> std 0
+    const windows: BiometricFeatureVector[] = [];
+    for (let i = 0; i < 30; i++) windows.push(fv([10, 20, 30][i % 3], 60));
+    const n = computePerUserNorm(windows, ['rmssd', 'hrMean'], 30)!;
+    expect(n).not.toBeNull();
+    expect(n.sampleCount).toBe(30);
+    expect(n.mean.rmssd).toBeCloseTo(20, 6);
+    expect(n.std.rmssd).toBeGreaterThan(0);
+    expect(n.mean.hrMean).toBeCloseTo(60, 6);
+    expect(n.std.hrMean).toBeCloseTo(0, 6); // constant feature -> std 0 (caller falls back)
+  });
+
+  test('omits features with too few usable (numeric, finite) samples', () => {
+    const windows: BiometricFeatureVector[] = [];
+    for (let i = 0; i < 30; i++) {
+      // rmssd always valid; hrMean only valid on a handful of windows
+      const w = fv(40, NaN);
+      if (i < 5) (w as any).hrMean = 70;
+      windows.push(w);
+    }
+    const n = computePerUserNorm(windows, ['rmssd', 'hrMean'], 30)!;
+    expect('rmssd' in n.mean).toBe(true);
+    expect('hrMean' in n.mean).toBe(false); // <30 usable -> omitted -> global fallback
+  });
+});

--- a/hooks/useWellness.tsx
+++ b/hooks/useWellness.tsx
@@ -26,8 +26,6 @@ import React, {
   ReactNode,
 } from 'react';
 import { Platform } from 'react-native';
-import * as FileSystem from 'expo-file-system';
-import { Asset } from 'expo-asset';
 import * as SQLite from 'expo-sqlite';
 
 import {
@@ -710,7 +708,9 @@ export function WellnessProvider({ children }: { children: ReactNode }) {
         featureHistory.current = featureHistory.current.slice(-4032);
       }
 
-      const stressPred = predictStress(featureVector, baseline);
+      // S1: pass the user's recent windows so the model can normalize per-subject
+      // (its headline accuracy lever) instead of the global training scaler.
+      const stressPred = predictStress(featureVector, baseline, featureHistory.current);
       setStress(stressPred);
 
       const anxietyPred = predictAnxiety(featureVector, baseline);

--- a/services/ai/perUserNorm.ts
+++ b/services/ai/perUserNorm.ts
@@ -1,0 +1,44 @@
+import type { BiometricFeatureVector } from './types';
+
+export interface PerUserNorm {
+  mean: Record<string, number>;
+  std: Record<string, number>;
+  sampleCount: number;
+}
+
+/**
+ * Per-subject (per-user) normalization — the generalization lever the model was trained
+ * with. Instead of the model's GLOBAL training mean/std, z-score each feature against the
+ * USER's own recent-window distribution (matching the per-subject z-norm used to reach the
+ * reported cross-dataset AUC).
+ *
+ * Returns null until there are at least `minSamples` windows (cold-start) so the caller
+ * falls back to global normalization. Features without enough usable samples are omitted,
+ * and the caller falls back to global for just those features.
+ */
+export function computePerUserNorm(
+  windows: BiometricFeatureVector[] | null | undefined,
+  featureNames: string[],
+  minSamples = 30,
+): PerUserNorm | null {
+  if (!windows || windows.length < minSamples) return null;
+
+  const mean: Record<string, number> = {};
+  const std: Record<string, number> = {};
+
+  for (const name of featureNames) {
+    const vals: number[] = [];
+    for (const w of windows) {
+      const v = (w as any)[name];
+      if (typeof v === 'number' && Number.isFinite(v)) vals.push(v);
+    }
+    if (vals.length < minSamples) continue; // fall back to global for this feature
+
+    const m = vals.reduce((s, x) => s + x, 0) / vals.length;
+    const variance = vals.reduce((s, x) => s + (x - m) * (x - m), 0) / vals.length;
+    mean[name] = m;
+    std[name] = Math.sqrt(variance);
+  }
+
+  return { mean, std, sampleCount: windows.length };
+}

--- a/services/ai/stressModel.ts
+++ b/services/ai/stressModel.ts
@@ -22,6 +22,7 @@ import {
   PersonalBaseline,
   FEATURE_NAMES,
 } from './types';
+import { computePerUserNorm, type PerUserNorm } from './perUserNorm';
 
 // ============================================================
 // XGBoost Model Types (matches JSON export format)
@@ -147,14 +148,18 @@ function xgboostPredict(model: XGBoostModel, features: Record<string, number>): 
  */
 function normalizeFeatures(
   features: BiometricFeatureVector,
-  model: XGBoostModel
+  model: XGBoostModel,
+  perUserNorm?: PerUserNorm | null,
 ): Record<string, number> {
   const normalized: Record<string, number> = {};
 
   model.features.forEach((name, i) => {
     const raw = (features as any)[name] ?? 0;
-    const mean = model.normalization.mean[name] ?? 0;
-    const stdDev = model.normalization.std[name] ?? 1;
+    // S1: prefer the user's own (per-subject) mean/std where available, else the model's
+    // global training scaler. Per-subject z-norm is the model's headline generalization lever.
+    const useUser = !!perUserNorm && name in perUserNorm.mean && (perUserNorm.std[name] ?? 0) > 0;
+    const mean = useUser ? perUserNorm!.mean[name] : (model.normalization.mean[name] ?? 0);
+    const stdDev = useUser ? perUserNorm!.std[name] : (model.normalization.std[name] ?? 1);
 
     let value: number;
     // Handle activityType encoding: sedentary=0, walking=1, active=2, sleeping=3
@@ -190,6 +195,7 @@ function normalizeFeatures(
 export function predictStress(
   features: BiometricFeatureVector,
   baseline?: PersonalBaseline | null,
+  recentWindows?: BiometricFeatureVector[] | null,
 ): StressPrediction {
   if (!cachedModel) {
     // Fallback: rule-based estimation if model isn't loaded
@@ -204,8 +210,10 @@ export function predictStress(
     return { ...fb, confidence: Math.min(fb.confidence, 0.3) };
   }
 
-  // Normalize features using training scaler
-  const normalizedFeatures = normalizeFeatures(features, cachedModel);
+  // S1: per-subject normalization from the user's recent windows (falls back to the
+  // model's global scaler per-feature until enough personal history exists).
+  const perUserNorm = computePerUserNorm(recentWindows ?? null, cachedModel.features);
+  const normalizedFeatures = normalizeFeatures(features, cachedModel, perUserNorm);
 
   // Run XGBoost inference
   const probability = xgboostPredict(cachedModel, normalizedFeatures);


### PR DESCRIPTION
Closes maturity gap **S1**. The stress model's headline accuracy lever is **per-subject z-normalization**, but the app was normalizing against the model's **global** training scaler. This z-scores each feature against the **user's own recent-window distribution**, falling back to global per-feature until enough personal history exists (≥30 windows / cold-start).

- `services/ai/perUserNorm.ts` — `computePerUserNorm(windows, features, minSamples)` (returns null at cold-start; omits features with too few usable samples → global fallback for those).
- `stressModel.ts` — `normalizeFeatures` + `predictStress(features, baseline, recentWindows)` prefer per-user mean/std.
- `useWellness` passes the in-memory `featureHistory` buffer.
- Removed now-dead `FileSystem`/`Asset` imports (leftover from the sleep TFLite migration).

**jest 175/175** (+3 perUserNorm unit tests).