### PR TITLE
fix: DB transactions/migrations (I4) + retryable sleep failures keep data (L5)

### DIFF
--- a/services/ai/db.ts
+++ b/services/ai/db.ts
@@ -42,6 +42,8 @@ export interface SQLiteDatabase {
   runAsync(sql: string, ...params: any[]): Promise<{ lastInsertRowId: number; changes: number }>;
   getFirstAsync<T>(sql: string, ...params: any[]): Promise<T | null>;
   getAllAsync<T>(sql: string, ...params: any[]): Promise<T[]>;
+  // expo-sqlite provides this; optional so a lightweight mock can omit it.
+  withTransactionAsync?(task: () => Promise<void>): Promise<void>;
 }
 
 // ============================================================
@@ -187,6 +189,24 @@ let db: SQLiteDatabase | null = null;
 export async function initDatabase(database: SQLiteDatabase): Promise<void> {
   db = database;
   await db.execAsync(CREATE_TABLES);
+  await runMigrations(database);
+}
+
+/**
+ * Version the schema via PRAGMA user_version so future changes apply once, in order.
+ * (CREATE TABLE IF NOT EXISTS handles fresh installs; this stamps the version and is the
+ * hook point for stepwise migrations.) Wrapped so a mock DB without PRAGMA can't break init.
+ */
+async function runMigrations(database: SQLiteDatabase): Promise<void> {
+  try {
+    const row = await database.getFirstAsync<{ user_version: number }>('PRAGMA user_version');
+    const current = row?.user_version ?? 0;
+    if (current >= SCHEMA_VERSION) return;
+    // Future: apply migrations for versions (current, SCHEMA_VERSION] here.
+    await database.execAsync(`PRAGMA user_version = ${SCHEMA_VERSION}`);
+  } catch (e) {
+    console.warn('[Seren] DB migration check skipped:', e);
+  }
 }
 
 /**
@@ -215,8 +235,16 @@ export async function insertBiometricSample(sample: Omit<DBBiometricSample, 'id'
 export async function insertBiometricSamplesBatch(
   samples: Omit<DBBiometricSample, 'id'>[],
 ): Promise<void> {
-  for (const sample of samples) {
-    await insertBiometricSample(sample);
+  if (samples.length === 0) return;
+  const database = getDb();
+  const run = async () => {
+    for (const sample of samples) await insertBiometricSample(sample);
+  };
+  // I4: wrap the batch in a single transaction (atomic + far faster than N autocommits).
+  if (database.withTransactionAsync) {
+    await database.withTransactionAsync(run);
+  } else {
+    await run();
   }
 }
 

--- a/services/ai/sleepReceiver.ts
+++ b/services/ai/sleepReceiver.ts
@@ -24,6 +24,7 @@ import {
   RawEpochFeatures,
   V32SleepOutput,
   runV32Inference,
+  isV32SleepModelLoaded,
 } from './sleepStageModel';
 
 const MAGIC = 0x314e5253;  // 'SRN1' little-endian
@@ -56,10 +57,24 @@ export async function processPendingSessions(): Promise<SessionResult[]> {
     const markerInfo = await FileSystem.getInfoAsync(finalMarker);
     if (!markerInfo.exists) continue; // session still being captured
 
+    // L5: if the model isn't loaded yet, KEEP the session and retry on a later open —
+    // don't consume + delete the raw overnight data with no model available to process it.
+    if (!isV32SleepModelLoaded()) {
+      results.push({
+        captureStartMs: parseInt(sessionName, 10),
+        epochsReceived: 0,
+        output: null,
+        skipped: 'model_not_loaded',
+      });
+      continue;
+    }
+
     const result = await processSession(sessionDir, parseInt(sessionName, 10));
     results.push(result);
 
-    // Clean up — comment this out during debugging so you can re-run.
+    // Delete only now that the model has had its chance: a null result here means the data
+    // is genuinely empty/too-short (won't improve on retry). Transient "model not loaded"
+    // is handled above, so raw data is never lost on a retryable failure.
     try {
       await FileSystem.deleteAsync(sessionDir, { idempotent: true });
     } catch (e) {


### PR DESCRIPTION
**I4** — `insertBiometricSamplesBatch` now runs in a single transaction (atomic + far faster than N autocommits); adds a `PRAGMA user_version` migration runner so schema changes apply once, in order. `withTransactionAsync` is optional on the DB interface (mock-friendly).

**L5** — `processPendingSessions` keeps a finalized sleep session for retry when the model isn't loaded yet, instead of deleting the raw overnight data unprocessed. Deletes only after the model has had its chance (success, or genuinely empty/too-short data) — so a transient failure no longer loses a night of captured data.

jest **175/175**.