### PR TITLE
feat: sleep hypnogram + on-device model confidence on home (gap L4)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -15,6 +15,7 @@ import { useWellness } from '@/hooks/useWellness';
 import { useAuth } from '@/hooks/useAuth';
 import { StressGauge } from '@/components/ui/StressGauge';
 import { GlassCard } from '@/components/ui/GlassCard';
+import { Hypnogram } from '@/components/ui/Hypnogram';
 
 export default function HomeScreen() {
   const insets = useSafeAreaInsets();
@@ -114,6 +115,19 @@ export default function HomeScreen() {
             </View>
           </GlassCard>
         </View>
+
+        {/* Last Night's Sleep — hypnogram (stage timeline + on-device model confidence) */}
+        <GlassCard variant="default" style={styles.sleepCard}>
+          <View style={styles.sleepCardHeader}>
+            <Text style={styles.metricLabel}>Last Night&apos;s Sleep</Text>
+            {lastSleep && (
+              <Text style={styles.metricSubInfo}>
+                {`${Math.floor(lastSleep.totalSleepMin / 60)}h ${lastSleep.totalSleepMin % 60}m · ${Math.round(lastSleep.qualityScore)}%`}
+              </Text>
+            )}
+          </View>
+          <Hypnogram stages={lastSleep?.stages} confidence={lastSleep?.mlConfidence} />
+        </GlassCard>
 
         {/* Sunlight Exposure Card */}
         <GlassCard variant="default" style={styles.sunlightCard}>
@@ -480,6 +494,19 @@ const styles = StyleSheet.create({
     borderRadius: Radius.xl,
     backgroundColor: Colors.warmWhite,
     borderWidth: 0,
+    marginBottom: Spacing.sm,
+  },
+  sleepCard: {
+    padding: Spacing.lg,
+    borderRadius: Radius.xl,
+    backgroundColor: Colors.warmWhite,
+    borderWidth: 0,
+    marginBottom: Spacing.sm,
+  },
+  sleepCardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
     marginBottom: Spacing.sm,
   },
   sunlightLeft: {

--- a/components/ui/Hypnogram.tsx
+++ b/components/ui/Hypnogram.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { View, Text, StyleSheet, Dimensions } from 'react-native';
+import Svg, { Rect, Line, Text as SvgText } from 'react-native-svg';
+import { Colors, FontSize, FontWeight, Spacing } from '@/constants/theme';
+import type { RawSleepStage, SleepStageType } from '@/services/ai/types';
+
+const { width } = Dimensions.get('window');
+
+// Hypnogram rows, top -> bottom (clinical convention: Awake on top, Deep at the bottom).
+const ROWS = ['awake', 'rem', 'light', 'deep'] as const;
+type Row = (typeof ROWS)[number];
+
+const LABELS: Record<Row, string> = { awake: 'Awake', rem: 'REM', light: 'Light', deep: 'Deep' };
+const ROW_COLOR: Record<Row, string> = {
+  awake: '#E8A87C', // amber
+  rem: '#9B8EC4',   // lavender
+  light: '#60A5FA', // blue
+  deep: '#3B5BA5',  // deep blue
+};
+
+// Map every SleepStageType onto one of the 4 hypnogram rows.
+function rowOf(stage: SleepStageType): Row {
+  switch (stage) {
+    case 'awake':
+    case 'out_of_bed':
+      return 'awake';
+    case 'rem':
+      return 'rem';
+    case 'deep':
+      return 'deep';
+    default:
+      return 'light'; // light, sleeping, unknown
+  }
+}
+
+interface HypnogramProps {
+  stages: RawSleepStage[] | undefined;
+  /** Mean per-epoch ML confidence (0-1). Shown only when present (on-device model). */
+  confidence?: number;
+  height?: number;
+  cardHorizontalPadding?: number;
+}
+
+export function Hypnogram({ stages, confidence, height = 116, cardHorizontalPadding = 80 }: HypnogramProps) {
+  if (!stages || stages.length === 0) {
+    return <Text style={styles.empty}>No stage timeline for last night.</Text>;
+  }
+
+  const svgW = width - cardHorizontalPadding;
+  const labelW = 42;
+  const chartW = Math.max(40, svgW - labelW - 6);
+  const topPad = 6;
+  const rowH = (height - topPad * 2) / ROWS.length;
+
+  const t0 = stages[0].startTime;
+  const t1 = stages[stages.length - 1].endTime;
+  const span = Math.max(1, t1 - t0);
+
+  const xAt = (t: number) => labelW + ((t - t0) / span) * chartW;
+  const rowCenterY = (r: Row) => topPad + ROWS.indexOf(r) * rowH + rowH / 2;
+
+  const fmt = (t: number) =>
+    new Date(t).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+
+  return (
+    <View>
+      <Svg width={svgW} height={height + 16}>
+        {ROWS.map((r, i) => {
+          const y = topPad + i * rowH + rowH / 2;
+          return (
+            <React.Fragment key={r}>
+              <Line x1={labelW} y1={y} x2={labelW + chartW} y2={y} stroke="#EEF2F7" strokeWidth={1} />
+              <SvgText x={0} y={y + 3} fontSize={9} fill={Colors.textMuted ?? '#94A3B8'}>
+                {LABELS[r]}
+              </SvgText>
+            </React.Fragment>
+          );
+        })}
+
+        {stages.map((seg, i) => {
+          const r = rowOf(seg.stage);
+          const xs = xAt(seg.startTime);
+          const xe = Math.max(xs + 2, xAt(seg.endTime));
+          return (
+            <Rect
+              key={i}
+              x={xs}
+              y={rowCenterY(r) - 4}
+              width={xe - xs}
+              height={8}
+              rx={3}
+              fill={ROW_COLOR[r]}
+            />
+          );
+        })}
+
+        {/* start / end time ticks */}
+        <SvgText x={labelW} y={height + 10} fontSize={9} fill={Colors.textMuted ?? '#94A3B8'}>
+          {fmt(t0)}
+        </SvgText>
+        <SvgText x={labelW + chartW} y={height + 10} fontSize={9} fill={Colors.textMuted ?? '#94A3B8'} textAnchor="end">
+          {fmt(t1)}
+        </SvgText>
+      </Svg>
+
+      {typeof confidence === 'number' && (
+        <View style={styles.confidenceRow}>
+          <View style={styles.mlDot} />
+          <Text style={styles.confidenceText}>
+            On-device model · {Math.round(confidence * 100)}% mean confidence
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  empty: {
+    fontSize: FontSize.sm,
+    color: Colors.textMuted ?? '#94A3B8',
+    paddingVertical: Spacing.md,
+  },
+  confidenceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: Spacing.xs,
+  },
+  mlDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: '#9B8EC4',
+    marginRight: 6,
+  },
+  confidenceText: {
+    fontSize: FontSize.xs ?? 11,
+    fontWeight: FontWeight.medium as any,
+    color: Colors.textSecondary ?? '#64748B',
+  },
+});

--- a/hooks/useWellness.tsx
+++ b/hooks/useWellness.tsx
@@ -356,8 +356,14 @@ export function WellnessProvider({ children }: { children: ReactNode }) {
           baseline,
           r.output.mlStages,
         );
-        setLastSleep(analysis);
-        sleepHistory.current.push(analysis);
+        // L4: mean per-epoch confidence from the on-device model -> surfaced in the UI.
+        const epochs = r.output.epochs;
+        const mlConfidence = epochs.length
+          ? epochs.reduce((s, e) => s + e.confidence, 0) / epochs.length
+          : undefined;
+        const enriched = { ...analysis, mlConfidence };
+        setLastSleep(enriched);
+        sleepHistory.current.push(enriched);
         setSleepTrend(computeSleepTrend(sleepHistory.current));
         if (dbReadyRef.current) {
           insertSleepSession(analysis).catch(() => {});

--- a/services/ai/index.ts
+++ b/services/ai/index.ts
@@ -30,8 +30,8 @@ export type { AnomalyFlag } from './baseline';
 export { analyzeSleepSession, computeSleepTrend } from './sleepAnalysis';
 export type { SleepTrend } from './sleepAnalysis';
 
-// ML sleep stage classification
-export { loadSleepModel, isSleepModelLoaded, classifySleepStages } from './sleepStageModel';
+// ML sleep stage classification (v3.2 on-device TFLite)
+export { loadV32SleepModel, isV32SleepModelLoaded, runV32Inference } from './sleepStageModel';
 
 // Voice check-in
 export { analyzeCheckin, analyzeCheckinLocal, computeCheckinTrend } from './voiceAnalysis';

--- a/services/ai/sleepAnalysis.ts
+++ b/services/ai/sleepAnalysis.ts
@@ -116,6 +116,7 @@ export function analyzeSleepSession(
     date,
     sessionStart: session.startTime,
     sessionEnd: session.endTime,
+    stages,  // per-night stage timeline for the hypnogram
 
     totalInBedMin: Math.round(totalInBedMin),
     totalSleepMin: Math.round(totalSleepMin),

--- a/services/ai/types.ts
+++ b/services/ai/types.ts
@@ -283,6 +283,12 @@ export interface SleepAnalysis {
   qualityScore: number;         // 0-100
   recoveryScore: number;        // 0-100 (HRV-based)
   consistencyScore: number;     // 0-100 (vs usual schedule)
+
+  // Per-night stage timeline (for the hypnogram). Optional: DB-loaded rows may omit it.
+  stages?: RawSleepStage[];
+  // Mean per-epoch confidence when stages came from the on-device ML model (0-1); absent
+  // for Health Connect / heuristic stages.
+  mlConfidence?: number;
 }
 
 // ----------------------------------------------------------


### PR DESCRIPTION
Makes the on-device sleep model **visible**: surfaces the per-night stage timeline + model confidence that were previously computed and thrown away.

- `SleepAnalysis` now carries `stages` (the timeline) + `mlConfidence` (mean per-epoch, ML only).
- `analyzeSleepSession` returns the timeline; `processWearSleepSessions` attaches the mean confidence from the v3.2 model.
- New **`components/ui/Hypnogram.tsx`** — SVG stage timeline (Awake / REM / Light / Deep, colored, with start/end times), matching the existing chart style.
- Home **"Last Night's Sleep"** card renders the hypnogram + duration/quality, and shows *"On-device model · NN% mean confidence"* when the night was ML-classified. Falls back gracefully to Health Connect / heuristic stages (hypnogram still renders, just without the confidence line).
- Bonus: fixed stale `services/ai/index.ts` sleep re-exports → **project is now tsc-clean (0 errors)**.

Validated: **jest 175/175**, **tsc 0 errors**. (Visual layout best confirmed on device — reload to see it.)