### PR TITLE
feat: runtime model monitoring (S6/L8) + sample-entropy optimization (S5)

### DIFF
--- a/__tests__/modelMonitor.test.ts
+++ b/__tests__/modelMonitor.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests — runtime model-health/drift monitor (gaps S6/L8).
+ */
+import {
+  recordStressPrediction,
+  getModelHealth,
+  _resetModelMonitor,
+} from '@/services/observability/modelMonitor';
+
+beforeEach(() => _resetModelMonitor());
+
+function feed(n: number, score: (i: number) => number, confidence: number) {
+  for (let i = 0; i < n; i++) {
+    recordStressPrediction({ stressScore: score(i), confidence, timestamp: i });
+  }
+}
+
+describe('modelMonitor', () => {
+  test('cold-start (< 20 samples) reports healthy / no drift', () => {
+    feed(10, (i) => 30 + i, 0.9);
+    const h = getModelHealth();
+    expect(h.samples).toBe(10);
+    expect(h.drift).toBe(false);
+  });
+
+  test('healthy: varied scores + high confidence -> no drift', () => {
+    feed(40, (i) => 20 + (i % 30), 0.85);
+    const h = getModelHealth();
+    expect(h.drift).toBe(false);
+    expect(h.meanConfidence).toBeCloseTo(0.85, 6);
+    expect(h.degenerate).toBe(false);
+  });
+
+  test('sustained low confidence -> drift flagged', () => {
+    feed(40, (i) => 20 + (i % 30), 0.2);
+    const h = getModelHealth();
+    expect(h.lowConfidenceRate).toBeCloseTo(1, 6);
+    expect(h.drift).toBe(true);
+    expect(h.reasons.join(' ')).toMatch(/low confidence/i);
+  });
+
+  test('degenerate (stuck) output -> drift flagged', () => {
+    feed(40, () => 50, 0.9); // identical score every window
+    const h = getModelHealth();
+    expect(h.degenerate).toBe(true);
+    expect(h.drift).toBe(true);
+    expect(h.reasons.join(' ')).toMatch(/not varying/i);
+  });
+
+  test('rolling window caps at 200 samples', () => {
+    feed(250, (i) => i % 50, 0.9);
+    expect(getModelHealth().samples).toBe(200);
+  });
+});

--- a/hooks/useWellness.tsx
+++ b/hooks/useWellness.tsx
@@ -59,6 +59,7 @@ import { computeBaseline, shouldRecomputeBaseline, detectAnomalies, AnomalyFlag 
 import { analyzeSleepSession, computeSleepTrend, SleepTrend } from '@/services/ai/sleepAnalysis';
 import { loadV32SleepModel, isV32SleepModelLoaded } from '@/services/ai/sleepStageModel';
 import { processPendingSessions } from '@/services/ai/sleepReceiver';
+import { recordStressPrediction } from '@/services/observability/modelMonitor';
 import { analyzeCheckin, computeCheckinTrend, CheckinTrend } from '@/services/ai/voiceAnalysis';
 import { generateRecommendations } from '@/services/ai/recommendations';
 import {
@@ -718,6 +719,7 @@ export function WellnessProvider({ children }: { children: ReactNode }) {
       // (its headline accuracy lever) instead of the global training scaler.
       const stressPred = predictStress(featureVector, baseline, featureHistory.current);
       setStress(stressPred);
+      recordStressPrediction(stressPred); // S6/L8: runtime model-health/drift monitoring
 
       const anxietyPred = predictAnxiety(featureVector, baseline);
       setAnxiety(anxietyPred);

--- a/services/ai/featureEngineering.ts
+++ b/services/ai/featureEngineering.ts
@@ -242,25 +242,30 @@ function computeSampleEntropy(data: number[], m: number, rFactor: number): numbe
   const r = rFactor * std(data);
   if (r === 0) return 0;
 
-  const countMatches = (templateLen: number): number => {
-    let count = 0;
-    for (let i = 0; i < N - templateLen; i++) {
-      for (let j = i + 1; j < N - templateLen; j++) {
-        let match = true;
-        for (let k = 0; k < templateLen; k++) {
-          if (Math.abs(data[i + k] - data[j + k]) >= r) {
-            match = false;
-            break;
-          }
+  // S5: single-pass count of m- and (m+1)-length template matches. Every (m+1) match is
+  // also an m match, so we extend the m-match check by one element instead of running the
+  // O(N^2) pair loop twice. Output is identical to the previous two-pass version; the
+  // index limits (limB / limA) reproduce its exact ranges.
+  let A = 0; // (m+1)-length matches
+  let B = 0; // m-length matches
+  const limB = N - m;
+  const limA = N - m - 1;
+  for (let i = 0; i < limB; i++) {
+    for (let j = i + 1; j < limB; j++) {
+      let mMatch = true;
+      for (let k = 0; k < m; k++) {
+        if (Math.abs(data[i + k] - data[j + k]) >= r) {
+          mMatch = false;
+          break;
         }
-        if (match) count++;
+      }
+      if (!mMatch) continue;
+      B++;
+      if (i < limA && j < limA && Math.abs(data[i + m] - data[j + m]) < r) {
+        A++;
       }
     }
-    return count;
-  };
-
-  const B = countMatches(m);
-  const A = countMatches(m + 1);
+  }
 
   if (B === 0 || A === 0) return 0;
   return -Math.log(A / B);

--- a/services/observability/modelMonitor.ts
+++ b/services/observability/modelMonitor.ts
@@ -1,0 +1,68 @@
+/**
+ * Runtime model-health / drift monitoring (gaps S6 / L8).
+ *
+ * Tracks a rolling window of recent on-device predictions and surfaces simple,
+ * dependency-free health signals — so "how do you detect model degradation / bad outputs?"
+ * has a concrete answer without any backend. Pure + in-memory; the UI (or Sentry, when a
+ * DSN is set) can read getModelHealth().
+ */
+
+interface Sample {
+  ts: number;
+  score: number;       // 0-100
+  confidence: number;  // 0-1
+}
+
+const MAX_SAMPLES = 200;
+const MIN_FOR_HEALTH = 20;
+const LOW_CONFIDENCE = 0.5;
+
+const recent: Sample[] = [];
+
+export interface ModelHealth {
+  samples: number;
+  meanConfidence: number;
+  lowConfidenceRate: number; // fraction below LOW_CONFIDENCE
+  degenerate: boolean;       // outputs stuck (≈zero variance) -> sensor/feature issue
+  drift: boolean;            // a health signal worth surfacing
+  reasons: string[];
+}
+
+/** Record one stress prediction. Cheap; call on every inference. */
+export function recordStressPrediction(p: { stressScore: number; confidence: number; timestamp?: number }): void {
+  recent.push({ ts: p.timestamp ?? 0, score: p.stressScore, confidence: p.confidence });
+  if (recent.length > MAX_SAMPLES) recent.shift();
+}
+
+/** Compute current model-health signals over the rolling window. */
+export function getModelHealth(): ModelHealth {
+  const n = recent.length;
+  if (n < MIN_FOR_HEALTH) {
+    return { samples: n, meanConfidence: 1, lowConfidenceRate: 0, degenerate: false, drift: false, reasons: [] };
+  }
+
+  const meanConfidence = recent.reduce((s, x) => s + x.confidence, 0) / n;
+  const lowConfidenceRate = recent.filter((x) => x.confidence < LOW_CONFIDENCE).length / n;
+
+  const meanScore = recent.reduce((s, x) => s + x.score, 0) / n;
+  const scoreVariance = recent.reduce((s, x) => s + (x.score - meanScore) ** 2, 0) / n;
+  const degenerate = scoreVariance < 1; // ~no movement across 20+ windows
+
+  const reasons: string[] = [];
+  if (lowConfidenceRate > 0.5) reasons.push(`low confidence on ${Math.round(lowConfidenceRate * 100)}% of recent windows`);
+  if (degenerate) reasons.push('stress score is not varying (possible sensor/feature issue)');
+
+  return {
+    samples: n,
+    meanConfidence,
+    lowConfidenceRate,
+    degenerate,
+    drift: reasons.length > 0,
+    reasons,
+  };
+}
+
+/** Test/reset hook. */
+export function _resetModelMonitor(): void {
+  recent.length = 0;
+}


### PR DESCRIPTION
Runtime model-health/drift monitor (getModelHealth: mean confidence, low-confidence rate, degenerate/stuck detection, drift flag) wired into the stress loop; sample-entropy counts m and m+1 matches in a single O(N^2) pass (identical output). jest 180/180, tsc 0. (L6 left as-is for training parity; L7 needs on-device profiling.)