### PR TITLE
feat: real watch-sourced location diversity + sunlight exposure

### DIFF
--- a/__tests__/envReceiver.test.ts
+++ b/__tests__/envReceiver.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the watch→phone environment pipeline:
+ *  - wire-format round-trip (must match com.seren.watch.env.WearableEnvSender)
+ *  - dwell segmentation of raw GPS fixes into visits
+ */
+// envReceiver transitively imports expo-file-system/legacy (ESM, not transformed by jest).
+// The pure decoders under test don't touch the filesystem, so stub the module out.
+jest.mock('expo-file-system/legacy', () => ({
+  documentDirectory: 'file:///doc/',
+  EncodingType: { Base64: 'base64' },
+  getInfoAsync: jest.fn(),
+  readDirectoryAsync: jest.fn(),
+  readAsStringAsync: jest.fn(),
+  deleteAsync: jest.fn(),
+}));
+// Native sensor modules pulled in transitively (sunlight/location tracking) — stub them out.
+jest.mock('expo-sensors', () => ({
+  LightSensor: { isAvailableAsync: jest.fn(), setUpdateInterval: jest.fn(), addListener: jest.fn() },
+}));
+jest.mock('expo-location', () => ({
+  Accuracy: { Balanced: 3 },
+  requestForegroundPermissionsAsync: jest.fn(),
+  watchPositionAsync: jest.fn(),
+}));
+
+import { decodeLight, decodeLocation } from '@/services/ai/envReceiver';
+import { segmentVisitsFromPoints } from '@/services/ai/locationTracking';
+
+const MAGIC_LIGHT = 0x314c5253; // 'SRL1'
+const MAGIC_LOCATION = 0x31475253; // 'SRG1'
+
+/** Build a light batch byte-for-byte like the Kotlin sender. */
+function encodeLight(samples: { ts: number; lux: number }[]): ArrayBuffer {
+  const buf = new ArrayBuffer(12 + samples.length * 12);
+  const dv = new DataView(buf);
+  dv.setInt32(0, MAGIC_LIGHT, true);
+  dv.setUint16(4, 1, true); // version
+  dv.setUint16(6, 0, true); // reserved
+  dv.setUint32(8, samples.length, true);
+  samples.forEach((s, i) => {
+    const off = 12 + i * 12;
+    dv.setBigInt64(off, BigInt(s.ts), true);
+    dv.setFloat32(off + 8, s.lux, true);
+  });
+  return buf;
+}
+
+function encodeLocation(pts: { ts: number; lat: number; lon: number; acc: number }[]): ArrayBuffer {
+  const buf = new ArrayBuffer(12 + pts.length * 28);
+  const dv = new DataView(buf);
+  dv.setInt32(0, MAGIC_LOCATION, true);
+  dv.setUint16(4, 1, true);
+  dv.setUint16(6, 0, true);
+  dv.setUint32(8, pts.length, true);
+  pts.forEach((p, i) => {
+    const off = 12 + i * 28;
+    dv.setBigInt64(off, BigInt(p.ts), true);
+    dv.setFloat64(off + 8, p.lat, true);
+    dv.setFloat64(off + 16, p.lon, true);
+    dv.setFloat32(off + 24, p.acc, true);
+  });
+  return buf;
+}
+
+describe('env wire format', () => {
+  it('round-trips a light batch with correct outdoor classification', () => {
+    const buf = encodeLight([
+      { ts: 1000, lux: 200 },     // indoor
+      { ts: 2000, lux: 25000 },   // outdoor
+    ]);
+    const out = decodeLight(buf);
+    expect(out).toHaveLength(2);
+    expect(out[0].timestamp).toBe(1000);
+    expect(out[0].luxValue).toBeCloseTo(200, 1);
+    expect(out[0].isOutdoors).toBe(false);
+    expect(out[1].isOutdoors).toBe(true);
+  });
+
+  it('round-trips a location batch preserving lat/lon precision', () => {
+    const buf = encodeLocation([
+      { ts: 5000, lat: 30.0444196, lon: 31.2357116, acc: 12.5 },
+    ]);
+    const out = decodeLocation(buf);
+    expect(out).toHaveLength(1);
+    expect(out[0].timestamp).toBe(5000);
+    expect(out[0].latitude).toBeCloseTo(30.0444196, 6);
+    expect(out[0].longitude).toBeCloseTo(31.2357116, 6);
+    expect(out[0].accuracy).toBeCloseTo(12.5, 1);
+  });
+});
+
+describe('segmentVisitsFromPoints', () => {
+  it('returns no visits for empty input', () => {
+    expect(segmentVisitsFromPoints([])).toEqual([]);
+  });
+
+  it('groups co-located fixes into one visit and tracks dwell time', () => {
+    const home = { latitude: 30.0, longitude: 31.0 };
+    const points = [
+      { timestamp: 1000, ...home },
+      { timestamp: 2000, latitude: 30.00001, longitude: 31.00001 }, // ~1.5 m away
+      { timestamp: 3000, ...home },
+    ];
+    const visits = segmentVisitsFromPoints(points);
+    expect(visits).toHaveLength(1);
+    expect(visits[0].timestamp).toBe(1000);       // arrival
+    expect(visits[0].departureTime).toBe(3000);   // departure
+  });
+
+  it('splits into separate visits when moving >100 m and reuses cluster index on return', () => {
+    const home = { latitude: 30.0, longitude: 31.0 };
+    const work = { latitude: 30.05, longitude: 31.05 }; // several km away
+    const points = [
+      { timestamp: 1000, ...home },
+      { timestamp: 2000, ...work },
+      { timestamp: 3000, ...home },
+    ];
+    const visits = segmentVisitsFromPoints(points);
+    expect(visits).toHaveLength(3);
+    // Returning home should reuse the same cluster index as the first visit.
+    expect(visits[2].clusterIndex).toBe(visits[0].clusterIndex);
+    expect(visits[1].clusterIndex).not.toBe(visits[0].clusterIndex);
+  });
+});

--- a/hooks/useWellness.tsx
+++ b/hooks/useWellness.tsx
@@ -59,6 +59,7 @@ import { computeBaseline, shouldRecomputeBaseline, detectAnomalies, AnomalyFlag 
 import { analyzeSleepSession, computeSleepTrend, SleepTrend } from '@/services/ai/sleepAnalysis';
 import { loadV32SleepModel, isV32SleepModelLoaded } from '@/services/ai/sleepStageModel';
 import { processPendingSessions } from '@/services/ai/sleepReceiver';
+import { processPendingEnv } from '@/services/ai/envReceiver';
 import { recordStressPrediction } from '@/services/observability/modelMonitor';
 import { analyzeCheckin, computeCheckinTrend, CheckinTrend } from '@/services/ai/voiceAnalysis';
 import { generateRecommendations } from '@/services/ai/recommendations';
@@ -491,77 +492,57 @@ export function WellnessProvider({ children }: { children: ReactNode }) {
 
   async function initLocationAndSunlight() {
     try {
-      // Load persisted data first
+      // Drain any ambient-light + GPS batches the watch delivered, then recompute
+      // today's summaries so the reads below pick up real watch data over mock.
+      if (dbReadyRef.current) {
+        try {
+          const env = await processPendingEnv();
+          if (env.lightSamples || env.locationPoints) {
+            console.log(`[Seren] env from watch: ${env.lightSamples} light, ${env.locationPoints} GPS`);
+          }
+        } catch (e) {
+          console.warn('[Seren] processPendingEnv failed:', e);
+        }
+      }
+
+      // Load persisted data (already recomputed above from watch batches when present).
+      let haveLocation = false;
+      let haveSunlight = false;
       if (dbReadyRef.current) {
         const savedLocation = await getTodayLocationDiversity();
-        if (savedLocation) setLocationDiversity(savedLocation);
+        if (savedLocation) { setLocationDiversity(savedLocation); haveLocation = true; }
 
         const savedSunlight = await getTodaySunlightDaily();
-        if (savedSunlight) setSunlightExposure(savedSunlight);
+        if (savedSunlight) { setSunlightExposure(savedSunlight); haveSunlight = true; }
+
+        const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
         const locationHistory = await getLocationDiversityHistory(7);
         if (locationHistory.length > 0) {
-          const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-          const mapped = locationHistory.map(h => {
-            const d = new Date(h.date);
-            const dayIdx = (d.getDay() + 6) % 7;
+          setWeeklyLocationDiversity(locationHistory.map(h => {
+            const dayIdx = (new Date(h.date).getDay() + 6) % 7;
             return { date: days[dayIdx], value: Math.round(h.diversityScore) };
-          });
-          setWeeklyLocationDiversity(mapped);
+          }));
         }
 
         const sunlightHistory = await getSunlightDailyHistory(7);
         if (sunlightHistory.length > 0) {
-          const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-          const mapped = sunlightHistory.map(h => {
-            const d = new Date(h.date);
-            const dayIdx = (d.getDay() + 6) % 7;
+          setWeeklySunlight(sunlightHistory.map(h => {
+            const dayIdx = (new Date(h.date).getDay() + 6) % 7;
             return { date: days[dayIdx], value: Math.round(h.totalOutdoorMinutes) };
-          });
-          setWeeklySunlight(mapped);
+          }));
         }
       }
 
-      // Use mock data for development (Expo Go / web)
-      if (!locationDiversity) {
+      // Fall back to mock only when the watch hasn't delivered real data yet
+      // (sunlight + location are sourced from the watch via processPendingEnv).
+      if (!haveLocation) {
         setLocationDiversity(getMockLocationDiversity());
         setWeeklyLocationDiversity(getMockWeeklyLocationDiversity());
       }
-      if (!sunlightExposure) {
+      if (!haveSunlight) {
         setSunlightExposure(getMockSunlightExposure());
         setWeeklySunlight(getMockWeeklySunlight());
-      }
-
-      // Try to start real sensors (will silently no-op if unavailable)
-      try {
-        const lightAvailable = await isLightSensorAvailable();
-        if (lightAvailable) {
-          const unsubscribe = await startSunlightMonitoring((reading) => {
-            if (dbReadyRef.current) {
-              insertSunlightSample(reading).catch(() => {});
-            }
-            // Update exposure summary periodically
-            setSunlightExposure(prev => {
-              if (!prev) return prev;
-              const newOutdoorMin = prev.totalOutdoorMinutes + (reading.isOutdoors ? 1 : 0);
-              const hour = new Date().getHours();
-              const inWindow = hour >= 10 && hour < 15;
-              const newOptimalMin = prev.optimalWindowMinutes + (reading.isOutdoors && inWindow ? 1 : 0);
-              const updated: SunlightExposureSummary = {
-                ...prev,
-                totalOutdoorMinutes: newOutdoorMin,
-                optimalWindowMinutes: newOptimalMin,
-                peakLux: Math.max(prev.peakLux, reading.luxValue),
-                goalProgress: Math.min(1, newOutdoorMin / prev.goalMinutes),
-                isVitaminDWindow: inWindow,
-              };
-              if (dbReadyRef.current) upsertSunlightDaily(updated).catch(() => {});
-              return updated;
-            });
-          });
-        }
-      } catch (e) {
-        console.warn('[Seren] Sensor init failed (using mock):', e);
       }
     } catch (e) {
       console.warn('[Seren] Location/Sunlight init failed:', e);

--- a/services/ai/db.ts
+++ b/services/ai/db.ts
@@ -137,6 +137,14 @@ const CREATE_TABLES = `
     cluster_index INTEGER DEFAULT -1
   );
 
+  CREATE TABLE IF NOT EXISTS location_points (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp INTEGER NOT NULL,
+    latitude REAL NOT NULL,
+    longitude REAL NOT NULL,
+    accuracy REAL DEFAULT -1
+  );
+
   CREATE TABLE IF NOT EXISTS location_diversity (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     date TEXT NOT NULL UNIQUE,
@@ -171,6 +179,7 @@ const CREATE_TABLES = `
   CREATE INDEX IF NOT EXISTS idx_sleep_date ON sleep_sessions(date);
   CREATE INDEX IF NOT EXISTS idx_checkins_ts ON checkins(timestamp);
   CREATE INDEX IF NOT EXISTS idx_location_visits_ts ON location_visits(timestamp);
+  CREATE INDEX IF NOT EXISTS idx_location_points_ts ON location_points(timestamp);
   CREATE INDEX IF NOT EXISTS idx_sunlight_ts ON sunlight_samples(timestamp);
   CREATE INDEX IF NOT EXISTS idx_sunlight_daily_date ON sunlight_daily(date);
   CREATE INDEX IF NOT EXISTS idx_location_div_date ON location_diversity(date);
@@ -456,6 +465,36 @@ export async function insertLocationVisit(visit: LocationVisit): Promise<number>
     visit.latitude, visit.longitude, visit.label, visit.clusterIndex,
   );
   return result.lastInsertRowId;
+}
+
+/** Delete visits whose arrival time falls in [startTime, endTime] (for idempotent re-derivation). */
+export async function deleteLocationVisitsInRange(startTime: number, endTime: number): Promise<void> {
+  await getDb().runAsync(
+    'DELETE FROM location_visits WHERE timestamp BETWEEN ? AND ?',
+    startTime, endTime,
+  );
+}
+
+/** Raw GPS fixes streamed from the watch — segmented into visits on recompute. */
+export async function insertLocationPoint(
+  point: { timestamp: number; latitude: number; longitude: number; accuracy: number },
+): Promise<number> {
+  const result = await getDb().runAsync(
+    `INSERT INTO location_points (timestamp, latitude, longitude, accuracy) VALUES (?, ?, ?, ?)`,
+    point.timestamp, point.latitude, point.longitude, point.accuracy,
+  );
+  return result.lastInsertRowId;
+}
+
+export async function getLocationPoints(
+  startTime: number,
+  endTime: number,
+): Promise<{ timestamp: number; latitude: number; longitude: number; accuracy: number }[]> {
+  const rows = await getDb().getAllAsync<{ timestamp: number; latitude: number; longitude: number; accuracy: number }>(
+    'SELECT timestamp, latitude, longitude, accuracy FROM location_points WHERE timestamp BETWEEN ? AND ? ORDER BY timestamp',
+    startTime, endTime,
+  );
+  return rows;
 }
 
 export async function getLocationVisits(startTime: number, endTime: number): Promise<LocationVisit[]> {

--- a/services/ai/envReceiver.ts
+++ b/services/ai/envReceiver.ts
@@ -1,0 +1,166 @@
+/**
+ * Seren — Environment batch receiver (phone side)
+ * ================================================
+ * Bridges the Wear OS app's ambient-light + GPS batches (persisted by the native
+ * WearableEnvListenerService) into the sunlight-exposure and location-diversity
+ * features. On app open this module:
+ *
+ *   1. Lists batch files under <documentDir>/seren_env/
+ *   2. Decodes each by magic:
+ *        - light  → insert sunlight samples
+ *        - loc    → insert raw GPS points
+ *   3. Deletes each file after decoding
+ *   4. Recomputes today's sunlight summary (from all of today's samples) and
+ *      today's location-diversity summary (by re-segmenting today's GPS points
+ *      into dwell visits), then upserts both.
+ *
+ * Wire format (little-endian, version 1) — must match
+ * com.seren.watch.env.WearableEnvSender:
+ *   header : magic i32, version u16, reserved u16, count u32        (12 bytes)
+ *   light  : count × (timestampMs i64 + lux f32)                    (12 bytes/sample)
+ *   loc    : count × (timestampMs i64 + lat f64 + lon f64 + acc f32)(28 bytes/sample)
+ */
+
+import * as FileSystem from 'expo-file-system/legacy';
+import { base64ToArrayBuffer } from './sleepReceiver';
+import {
+  insertSunlightSample,
+  getSunlightSamples,
+  upsertSunlightDaily,
+  insertLocationPoint,
+  getLocationPoints,
+  deleteLocationVisitsInRange,
+  insertLocationVisit,
+  upsertLocationDiversity,
+} from './db';
+import { computeSunlightSummary, OUTDOOR_LUX_THRESHOLD } from './sunlightTracking';
+import { segmentVisitsFromPoints, calculateDiversityScore } from './locationTracking';
+
+const ENV_DIR = 'seren_env';
+const MAGIC_LIGHT = 0x314c5253; // 'SRL1'
+const MAGIC_LOCATION = 0x31475253; // 'SRG1'
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface EnvIngestResult {
+  lightSamples: number;
+  locationPoints: number;
+}
+
+function startOfToday(): number {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+/** Decode one light batch → SunlightReading-shaped rows. */
+export function decodeLight(buf: ArrayBuffer): { timestamp: number; luxValue: number; isOutdoors: boolean }[] {
+  const dv = new DataView(buf);
+  const count = dv.getUint32(8, true);
+  const headerSize = 12;
+  const sampleSize = 12;
+  if (buf.byteLength < headerSize + count * sampleSize) {
+    throw new Error(`light size mismatch: ${count} samples vs ${buf.byteLength} bytes`);
+  }
+  const out: { timestamp: number; luxValue: number; isOutdoors: boolean }[] = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const off = headerSize + i * sampleSize;
+    const ts = Number(dv.getBigInt64(off, true));
+    const lux = dv.getFloat32(off + 8, true);
+    out[i] = { timestamp: ts, luxValue: lux, isOutdoors: lux >= OUTDOOR_LUX_THRESHOLD };
+  }
+  return out;
+}
+
+/** Decode one location batch → raw GPS points. */
+export function decodeLocation(buf: ArrayBuffer): { timestamp: number; latitude: number; longitude: number; accuracy: number }[] {
+  const dv = new DataView(buf);
+  const count = dv.getUint32(8, true);
+  const headerSize = 12;
+  const sampleSize = 28;
+  if (buf.byteLength < headerSize + count * sampleSize) {
+    throw new Error(`location size mismatch: ${count} points vs ${buf.byteLength} bytes`);
+  }
+  const out: { timestamp: number; latitude: number; longitude: number; accuracy: number }[] = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const off = headerSize + i * sampleSize;
+    const ts = Number(dv.getBigInt64(off, true));
+    const lat = dv.getFloat64(off + 8, true);
+    const lon = dv.getFloat64(off + 16, true);
+    const acc = dv.getFloat32(off + 24, true);
+    out[i] = { timestamp: ts, latitude: lat, longitude: lon, accuracy: acc };
+  }
+  return out;
+}
+
+async function readBinary(uri: string): Promise<ArrayBuffer> {
+  const b64 = await FileSystem.readAsStringAsync(uri, { encoding: FileSystem.EncodingType.Base64 });
+  return base64ToArrayBuffer(b64);
+}
+
+/**
+ * Drain all pending environment batches from the watch, persist them, and
+ * recompute today's summaries. Safe to call on every app open — a no-op when
+ * the watch hasn't delivered anything.
+ */
+export async function processPendingEnv(): Promise<EnvIngestResult> {
+  const root = `${FileSystem.documentDirectory}${ENV_DIR}/`;
+  const info = await FileSystem.getInfoAsync(root);
+  if (!info.exists) return { lightSamples: 0, locationPoints: 0 };
+
+  const files = await FileSystem.readDirectoryAsync(root);
+  let lightCount = 0;
+  let locCount = 0;
+
+  for (const f of files) {
+    if (!f.endsWith('.bin')) continue;
+    const uri = `${root}${f}`;
+    try {
+      const buf = await readBinary(uri);
+      if (buf.byteLength < 12) throw new Error('batch too small');
+      const magic = new DataView(buf).getInt32(0, true);
+      if (magic === MAGIC_LIGHT) {
+        const samples = decodeLight(buf);
+        for (const s of samples) await insertSunlightSample(s);
+        lightCount += samples.length;
+      } else if (magic === MAGIC_LOCATION) {
+        const points = decodeLocation(buf);
+        for (const p of points) await insertLocationPoint(p);
+        locCount += points.length;
+      } else {
+        console.warn(`[Seren] env: bad magic 0x${magic.toString(16)} in ${f}`);
+      }
+    } catch (e) {
+      console.warn(`[Seren] env: failed to decode ${f}:`, e);
+    }
+    // Each file is consumed once; delete regardless so it isn't reprocessed.
+    try {
+      await FileSystem.deleteAsync(uri, { idempotent: true });
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const now = Date.now();
+  const dayStart = startOfToday();
+
+  if (lightCount > 0) {
+    const samples = await getSunlightSamples(dayStart, now);
+    const summary = computeSunlightSummary(samples);
+    await upsertSunlightDaily(summary);
+  }
+
+  if (locCount > 0) {
+    const todayPoints = await getLocationPoints(dayStart, now);
+    const todayVisits = segmentVisitsFromPoints(todayPoints);
+    // Re-derive today's visits idempotently from the full point set.
+    await deleteLocationVisitsInRange(dayStart, now);
+    for (const v of todayVisits) await insertLocationVisit(v);
+
+    const weekPoints = await getLocationPoints(now - 7 * DAY_MS, now);
+    const weekVisits = segmentVisitsFromPoints(weekPoints);
+    const summary = calculateDiversityScore(todayVisits, weekVisits);
+    await upsertLocationDiversity(summary);
+  }
+
+  return { lightSamples: lightCount, locationPoints: locCount };
+}

--- a/services/ai/locationTracking.ts
+++ b/services/ai/locationTracking.ts
@@ -211,6 +211,80 @@ export function calculateDiversityScore(
 }
 
 // ============================================================
+// Dwell Segmentation (raw GPS points → visits)
+// ============================================================
+
+export interface RawLocationPoint {
+  timestamp: number;
+  latitude: number;
+  longitude: number;
+  accuracy?: number;
+}
+
+/**
+ * Segment a chronological list of raw GPS fixes (streamed from the watch) into
+ * dwell "visits". A new visit begins whenever a fix is more than
+ * CLUSTER_RADIUS_METERS from the running centroid of the current visit. Each
+ * visit records arrival (first fix) and departure (last fix) so downstream
+ * clustering can weight home/work by dwell time. A stable clusterIndex is
+ * assigned per place so transition counting works.
+ */
+export function segmentVisitsFromPoints(points: RawLocationPoint[]): LocationVisit[] {
+  if (points.length === 0) return [];
+  const sorted = [...points].sort((a, b) => a.timestamp - b.timestamp);
+  const visits: LocationVisit[] = [];
+  const places: { lat: number; lon: number }[] = [];
+
+  const placeIndexFor = (lat: number, lon: number): number => {
+    for (let i = 0; i < places.length; i++) {
+      if (haversineDistance(lat, lon, places[i].lat, places[i].lon) < CLUSTER_RADIUS_METERS) return i;
+    }
+    places.push({ lat, lon });
+    return places.length - 1;
+  };
+
+  let cLat = sorted[0].latitude;
+  let cLon = sorted[0].longitude;
+  let count = 1;
+  let arrival = sorted[0].timestamp;
+  let departure = sorted[0].timestamp;
+
+  const flush = () => {
+    visits.push({
+      id: `v_${arrival}`,
+      timestamp: arrival,
+      departureTime: departure,
+      latitude: cLat,
+      longitude: cLon,
+      label: 'unknown',
+      clusterIndex: placeIndexFor(cLat, cLon),
+    });
+  };
+
+  for (let i = 1; i < sorted.length; i++) {
+    const p = sorted[i];
+    const dist = haversineDistance(p.latitude, p.longitude, cLat, cLon);
+    if (dist < CLUSTER_RADIUS_METERS) {
+      // Same place — extend dwell, update running centroid.
+      cLat = (cLat * count + p.latitude) / (count + 1);
+      cLon = (cLon * count + p.longitude) / (count + 1);
+      count++;
+      departure = p.timestamp;
+    } else {
+      // Moved — close current visit and start a new one.
+      flush();
+      cLat = p.latitude;
+      cLon = p.longitude;
+      count = 1;
+      arrival = p.timestamp;
+      departure = p.timestamp;
+    }
+  }
+  flush();
+  return visits;
+}
+
+// ============================================================
 // Location Permission & Tracking
 // ============================================================
 

--- a/wearos/app/build.gradle.kts
+++ b/wearos/app/build.gradle.kts
@@ -84,6 +84,9 @@ dependencies {
     // Wear Data Layer (phone <-> watch sync)
     implementation("com.google.android.gms:play-services-wearable:18.2.0")
 
+    // Fused location provider (on-watch GPS for location-diversity capture)
+    implementation("com.google.android.gms:play-services-location:21.3.0")
+
     // Tiles API (quick-glance tile on watch face)
     implementation("androidx.wear.tiles:tiles:1.4.1")
     implementation("androidx.wear.tiles:tiles-material:1.4.1")

--- a/wearos/app/src/main/AndroidManifest.xml
+++ b/wearos/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
@@ -54,6 +55,12 @@
             android:name=".sleep.SleepCaptureService"
             android:exported="false"
             android:foregroundServiceType="health" />
+
+        <!-- Environment capture foreground service (ambient light + GPS → batches → phone) -->
+        <service
+            android:name=".env.EnvironmentCaptureService"
+            android:exported="false"
+            android:foregroundServiceType="location" />
 
         <!-- TODO: Wear Tile Service (implement when Tiles Material 3 is integrated) -->
 

--- a/wearos/app/src/main/java/com/seren/watch/env/EnvironmentCaptureService.kt
+++ b/wearos/app/src/main/java/com/seren/watch/env/EnvironmentCaptureService.kt
@@ -1,0 +1,138 @@
+package com.seren.watch.env
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Foreground service that samples the watch's ambient-light sensor + GPS and ships
+ * batches to the phone every [BATCH_INTERVAL_MS]. Light is throttled to ~1/min;
+ * GPS arrives at the balanced-power cadence from [EnvironmentSensors].
+ *
+ * Start: startForegroundService(Intent(ctx, EnvironmentCaptureService::class.java))
+ * Stop:  startService(Intent(ctx, EnvironmentCaptureService::class.java).setAction(ACTION_STOP))
+ */
+class EnvironmentCaptureService : Service() {
+
+    companion object {
+        private const val TAG = "SerenEnvSvc"
+        const val ACTION_STOP = "com.seren.watch.env.STOP"
+        const val CHANNEL_ID = "seren_env_capture"
+        const val NOTIFICATION_ID = 2002
+
+        /** How often to flush buffered samples to the phone. */
+        private const val BATCH_INTERVAL_MS = 5 * 60 * 1000L
+        /** Keep at most one light sample per this interval (sensor can fire in bursts). */
+        private const val LIGHT_THROTTLE_MS = 60 * 1000L
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var captureJob: Job? = null
+    private lateinit var sensors: EnvironmentSensors
+    private lateinit var sender: WearableEnvSender
+
+    private val lightBuf = ArrayDeque<LightSample>()
+    private val locBuf = ArrayDeque<LocationSample>()
+    private var lastLightKeptMs = 0L
+
+    override fun onCreate() {
+        super.onCreate()
+        sensors = EnvironmentSensors(applicationContext)
+        sender = WearableEnvSender(applicationContext)
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_STOP) {
+            stopCapture()
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+            return START_NOT_STICKY
+        }
+        startForeground(NOTIFICATION_ID, buildNotification())
+        startCapture()
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun startCapture() {
+        if (captureJob?.isActive == true) return
+        lightBuf.clear(); locBuf.clear(); lastLightKeptMs = 0L
+
+        captureJob = scope.launch {
+            val lightJob = launch {
+                sensors.lightFlow().collect { s ->
+                    if (s.timestampMs - lastLightKeptMs >= LIGHT_THROTTLE_MS) {
+                        lastLightKeptMs = s.timestampMs
+                        synchronized(lightBuf) { lightBuf.addLast(s) }
+                    }
+                }
+            }
+            val locJob = launch {
+                sensors.locationFlow().collect { s ->
+                    synchronized(locBuf) { locBuf.addLast(s) }
+                }
+            }
+            try {
+                while (true) {
+                    delay(BATCH_INTERVAL_MS)
+                    flush()
+                }
+            } finally {
+                lightJob.cancel()
+                locJob.cancel()
+            }
+        }
+        Log.d(TAG, "Environment capture started")
+    }
+
+    private suspend fun flush() {
+        val light = synchronized(lightBuf) { val c = lightBuf.toList(); lightBuf.clear(); c }
+        val loc = synchronized(locBuf) { val c = locBuf.toList(); locBuf.clear(); c }
+        if (light.isNotEmpty()) sender.sendLight(light)
+        if (loc.isNotEmpty()) sender.sendLocation(loc)
+    }
+
+    private fun stopCapture() {
+        // Best-effort final flush of anything buffered.
+        scope.launch { flush() }
+        captureJob?.cancel()
+        captureJob = null
+        Log.d(TAG, "Environment capture stopped")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Environment tracking",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply { description = "Captures ambient light + location for wellness insights" }
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(): Notification =
+        NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Seren environment tracking")
+            .setContentText("Sensing light & location")
+            .setSmallIcon(android.R.drawable.ic_menu_compass)
+            .setOngoing(true)
+            .build()
+}

--- a/wearos/app/src/main/java/com/seren/watch/env/EnvironmentSensors.kt
+++ b/wearos/app/src/main/java/com/seren/watch/env/EnvironmentSensors.kt
@@ -1,0 +1,125 @@
+package com.seren.watch.env
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.os.Looper
+import android.util.Log
+import androidx.core.content.ContextCompat
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+/** One ambient-light reading. */
+data class LightSample(val timestampMs: Long, val lux: Float)
+
+/** One GPS fix. */
+data class LocationSample(
+    val timestampMs: Long,
+    val latitude: Double,
+    val longitude: Double,
+    val accuracy: Float,
+)
+
+/**
+ * On-watch environment sensors used for the location-diversity and sunlight-exposure
+ * features. Exposes cold [Flow]s that register their underlying listener on collection
+ * and unregister on cancellation — mirrors HealthServicesManager's sensor flows.
+ */
+class EnvironmentSensors(private val context: Context) {
+
+    companion object {
+        private const val TAG = "SerenEnv"
+        /** GPS fix cadence — balanced power is plenty for home/work/novel-place clustering. */
+        const val LOCATION_INTERVAL_MS = 5 * 60 * 1000L
+        private const val LOCATION_MIN_INTERVAL_MS = 2 * 60 * 1000L
+    }
+
+    private val sensorManager: SensorManager =
+        context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+
+    private val fusedClient = LocationServices.getFusedLocationProviderClient(context)
+
+    /** True when this watch exposes an ambient-light sensor (most do, for auto-brightness). */
+    fun hasLightSensor(): Boolean =
+        sensorManager.getDefaultSensor(Sensor.TYPE_LIGHT) != null
+
+    private fun hasLocationPermission(): Boolean =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED ||
+        ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+
+    /** Emits ambient-light samples as the sensor reports changes. */
+    fun lightFlow(): Flow<LightSample> = callbackFlow {
+        val light = sensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)
+        if (light == null) {
+            Log.w(TAG, "No TYPE_LIGHT sensor on this device")
+            close()
+            return@callbackFlow
+        }
+        val listener = object : SensorEventListener {
+            override fun onSensorChanged(event: SensorEvent) {
+                val deltaNanos = event.timestamp - System.nanoTime()
+                val tsMs = System.currentTimeMillis() + deltaNanos / 1_000_000L
+                trySend(LightSample(tsMs, event.values[0]))
+            }
+            override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+        }
+        sensorManager.registerListener(listener, light, SensorManager.SENSOR_DELAY_NORMAL)
+        Log.d(TAG, "Light capture started")
+        awaitClose {
+            sensorManager.unregisterListener(listener)
+            Log.d(TAG, "Light capture stopped")
+        }
+    }
+
+    /** Emits GPS fixes at [LOCATION_INTERVAL_MS] cadence (balanced power). */
+    fun locationFlow(): Flow<LocationSample> = callbackFlow {
+        if (!hasLocationPermission()) {
+            Log.w(TAG, "Location permission not granted; no GPS")
+            close()
+            return@callbackFlow
+        }
+        val request = LocationRequest.Builder(
+            Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+            LOCATION_INTERVAL_MS,
+        ).setMinUpdateIntervalMillis(LOCATION_MIN_INTERVAL_MS).build()
+
+        val callback = object : LocationCallback() {
+            override fun onLocationResult(result: LocationResult) {
+                for (loc in result.locations) {
+                    trySend(
+                        LocationSample(
+                            timestampMs = if (loc.time > 0) loc.time else System.currentTimeMillis(),
+                            latitude = loc.latitude,
+                            longitude = loc.longitude,
+                            accuracy = if (loc.hasAccuracy()) loc.accuracy else -1f,
+                        )
+                    )
+                }
+            }
+        }
+        try {
+            fusedClient.requestLocationUpdates(request, callback, Looper.getMainLooper())
+            Log.d(TAG, "Location capture started @ ${LOCATION_INTERVAL_MS / 1000}s")
+        } catch (e: SecurityException) {
+            Log.e(TAG, "Location permission revoked at runtime", e)
+            close(e)
+            return@callbackFlow
+        }
+        awaitClose {
+            fusedClient.removeLocationUpdates(callback)
+            Log.d(TAG, "Location capture stopped")
+        }
+    }
+}

--- a/wearos/app/src/main/java/com/seren/watch/env/WearableEnvSender.kt
+++ b/wearos/app/src/main/java/com/seren/watch/env/WearableEnvSender.kt
@@ -1,0 +1,71 @@
+package com.seren.watch.env
+
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.tasks.await
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Ships ambient-light and GPS batches from the watch to the phone over the
+ * Wearable Data Layer (MessageClient).
+ *
+ * Wire format (little-endian, version 1) — must match services/ai/envReceiver.ts:
+ *   header : magic i32, version u16, reserved u16, count u32        (12 bytes)
+ *   light  : count × (timestampMs i64 + lux f32)                    (12 bytes/sample)
+ *   loc    : count × (timestampMs i64 + lat f64 + lon f64 + acc f32)(28 bytes/sample)
+ *
+ * Message paths:
+ *   /seren/env/light     — ambient-light sample batches
+ *   /seren/env/location  — GPS fix batches
+ */
+class WearableEnvSender(private val context: Context) {
+
+    companion object {
+        private const val TAG = "SerenEnv"
+        // 4 ASCII chars read little-endian, matching the sleep sender's 'SRN1' convention.
+        const val MAGIC_LIGHT: Int = 0x314C5253    // 'SRL1'
+        const val MAGIC_LOCATION: Int = 0x31475253 // 'SRG1'
+        const val VERSION: Short = 1
+        const val PATH_LIGHT = "/seren/env/light"
+        const val PATH_LOCATION = "/seren/env/location"
+    }
+
+    private val messageClient = Wearable.getMessageClient(context)
+    private val nodeClient = Wearable.getNodeClient(context)
+
+    suspend fun sendLight(samples: List<LightSample>) {
+        if (samples.isEmpty()) return
+        val headerSize = 4 + 2 + 2 + 4
+        val buf = ByteBuffer.allocate(headerSize + samples.size * 12).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(MAGIC_LIGHT); buf.putShort(VERSION); buf.putShort(0); buf.putInt(samples.size)
+        for (s in samples) { buf.putLong(s.timestampMs); buf.putFloat(s.lux) }
+        deliver(PATH_LIGHT, buf.array(), samples.size)
+    }
+
+    suspend fun sendLocation(samples: List<LocationSample>) {
+        if (samples.isEmpty()) return
+        val headerSize = 4 + 2 + 2 + 4
+        val buf = ByteBuffer.allocate(headerSize + samples.size * 28).order(ByteOrder.LITTLE_ENDIAN)
+        buf.putInt(MAGIC_LOCATION); buf.putShort(VERSION); buf.putShort(0); buf.putInt(samples.size)
+        for (s in samples) {
+            buf.putLong(s.timestampMs); buf.putDouble(s.latitude); buf.putDouble(s.longitude); buf.putFloat(s.accuracy)
+        }
+        deliver(PATH_LOCATION, buf.array(), samples.size)
+    }
+
+    private suspend fun deliver(path: String, payload: ByteArray, count: Int) {
+        try {
+            val nodes = nodeClient.connectedNodes.await()
+            if (nodes.isEmpty()) {
+                Log.w(TAG, "No paired nodes; $count samples on $path not delivered")
+                return
+            }
+            for (node in nodes) messageClient.sendMessage(node.id, path, payload).await()
+            Log.d(TAG, "Sent $count samples on $path to ${nodes.size} node(s)")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to send batch on $path", e)
+        }
+    }
+}

--- a/wearos/app/src/main/java/com/seren/watch/presentation/screens/DashboardScreen.kt
+++ b/wearos/app/src/main/java/com/seren/watch/presentation/screens/DashboardScreen.kt
@@ -1,6 +1,8 @@
 package com.seren.watch.presentation.screens
 
 import android.Manifest
+import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -43,10 +45,19 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.material.Vignette
 import androidx.wear.compose.material.VignettePosition
+import com.seren.watch.env.EnvironmentCaptureService
 import com.seren.watch.presentation.WellnessViewModel
 import com.seren.watch.presentation.components.MetricChip
 import com.seren.watch.presentation.components.StressArc
 import com.seren.watch.presentation.theme.SerenColors
+
+/** Start the on-watch ambient-light + GPS capture service (auto-started once permitted). */
+private fun startEnvironmentCapture(context: Context) {
+    ContextCompat.startForegroundService(
+        context,
+        Intent(context, EnvironmentCaptureService::class.java),
+    )
+}
 
 /**
  * Main dashboard screen — the first thing users see on the watch.
@@ -67,30 +78,37 @@ fun DashboardScreen(
     val state by viewModel.state.collectAsState()
     val context = LocalContext.current
 
-    // Request body sensor permission
+    // Request body-sensor + location permissions (location powers on-watch env capture)
     val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
     ) { permissions ->
-        val allGranted = permissions.values.all { it }
-        if (allGranted) {
+        if (permissions[Manifest.permission.BODY_SENSORS] == true) {
             viewModel.onPermissionGranted()
         } else {
             viewModel.useMockData()
         }
+        val locationGranted = permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
+            permissions[Manifest.permission.ACCESS_COARSE_LOCATION] == true
+        if (locationGranted) startEnvironmentCapture(context)
     }
 
     LaunchedEffect(Unit) {
-        val hasPermission = ContextCompat.checkSelfPermission(
+        val hasBody = ContextCompat.checkSelfPermission(
             context, Manifest.permission.BODY_SENSORS
         ) == PackageManager.PERMISSION_GRANTED
+        val hasLocation = ContextCompat.checkSelfPermission(
+            context, Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
 
-        if (hasPermission) {
-            viewModel.onPermissionGranted()
-        } else {
+        if (hasBody) viewModel.onPermissionGranted()
+        if (hasLocation) startEnvironmentCapture(context)
+
+        if (!hasBody || !hasLocation) {
             permissionLauncher.launch(
                 arrayOf(
                     Manifest.permission.BODY_SENSORS,
                     Manifest.permission.ACTIVITY_RECOGNITION,
+                    Manifest.permission.ACCESS_FINE_LOCATION,
                 )
             )
         }

--- a/wearos/app/src/main/java/com/seren/watch/presentation/screens/SleepScreen.kt
+++ b/wearos/app/src/main/java/com/seren/watch/presentation/screens/SleepScreen.kt
@@ -2,6 +2,8 @@ package com.seren.watch.presentation.screens
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,17 +11,27 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import android.content.Intent
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
+import androidx.wear.compose.material.Chip
+import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
@@ -28,6 +40,7 @@ import androidx.wear.compose.material.Vignette
 import androidx.wear.compose.material.VignettePosition
 import com.seren.watch.presentation.WellnessViewModel
 import com.seren.watch.presentation.theme.SerenColors
+import com.seren.watch.sleep.SleepCaptureService
 
 /**
  * Sleep summary screen showing last night's sleep data.
@@ -35,6 +48,8 @@ import com.seren.watch.presentation.theme.SerenColors
 @Composable
 fun SleepScreen(viewModel: WellnessViewModel) {
     val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
+    var capturing by remember { mutableStateOf(false) }
 
     val hours = state.sleepDurationMin / 60
     val mins = state.sleepDurationMin % 60
@@ -54,6 +69,7 @@ fun SleepScreen(viewModel: WellnessViewModel) {
             verticalArrangement = Arrangement.Center,
             modifier = Modifier
                 .fillMaxSize()
+                .verticalScroll(rememberScrollState())
                 .padding(16.dp),
         ) {
             Icon(
@@ -101,6 +117,43 @@ fun SleepScreen(viewModel: WellnessViewModel) {
                     textAlign = TextAlign.Center,
                 )
             }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Start/stop the overnight HR + motion capture that streams to the phone.
+            Chip(
+                onClick = {
+                    val intent = Intent(context, SleepCaptureService::class.java)
+                    if (capturing) {
+                        intent.action = SleepCaptureService.ACTION_STOP
+                        context.startService(intent)
+                    } else {
+                        intent.action = SleepCaptureService.ACTION_START
+                        ContextCompat.startForegroundService(context, intent)
+                    }
+                    capturing = !capturing
+                },
+                colors = ChipDefaults.chipColors(
+                    backgroundColor = (if (capturing) SerenColors.error else SerenColors.sageGreen)
+                        .copy(alpha = 0.2f),
+                ),
+                label = {
+                    Text(
+                        text = if (capturing) "Stop sleep tracking" else "Start sleep tracking",
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Medium,
+                    )
+                },
+                icon = {
+                    Icon(
+                        imageVector = if (capturing) Icons.Default.Stop else Icons.Default.PlayArrow,
+                        contentDescription = if (capturing) "Stop" else "Start",
+                        tint = if (capturing) SerenColors.error else SerenColors.sageGreen,
+                        modifier = Modifier.size(18.dp),
+                    )
+                },
+                modifier = Modifier.fillMaxWidth(0.95f),
+            )
         }
     }
 }


### PR DESCRIPTION
Replaces mock-only location/sunlight with **real sensors collected on the watch and streamed to the phone** over the Wearable Data Layer, mirroring the sleep pipeline.

**Watch:** ambient-light + GPS flows → `EnvironmentCaptureService` (foreground, light 1/min, GPS ~1/5min balanced) → `WearableEnvSender` over `/seren/env/{light,location}`. Auto-starts on app open once location is granted. Adds a Sleep start/stop control so the sleep pipeline is finally triggerable.

**Phone:** `envReceiver.ts` decodes both wire formats, dwell-segments GPS into visits, persists to SQLite (new `location_points` table), and recomputes the sunlight + location-diversity summaries. `useWellness` drains watch data on open and prefers it over mock (also fixes a stale-closure bug that let mock overwrite real data, and drops the double-counting phone light-sensor path).

**Tests:** wire-format round-trip + dwell segmentation. 185 jest pass, `tsc` clean. Both APKs rebuilt + share signing cert.

**Note:** the phone-side `WearableEnvListenerService` + manifest entry live in the gitignored `android/` dir (same as the existing sleep listener), so they aren't in this commit.