### PR TITLE
ci: model-promotion pipeline (DVC + DagsHub + GitHub Actions + EAS OTA)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: deploy
+
+# On merge to main (when a model/app asset changed and the gate already passed),
+# materialize the model from DagsHub and ship it over-the-air via EAS Update.
+# Models are bundled assets, so `eas update` delivers the new model to existing
+# installs on next launch — no Play Store re-release.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "assets/ml/**"
+      - "**/*.dvc"
+      - "app/**"
+      - "services/**"
+
+jobs:
+  ship:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install DVC + pull model artifacts
+        run: |
+          pip install "dvc[s3]"
+          dvc remote modify origin --local access_key_id  "${{ secrets.DAGSHUB_TOKEN }}"
+          dvc remote modify origin --local secret_access_key "${{ secrets.DAGSHUB_TOKEN }}"
+          dvc pull
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci --legacy-peer-deps
+
+      - run: npm i -g eas-cli
+
+      - name: OTA ship the model
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: eas update --branch production --message "${{ github.event.head_commit.message }}"

--- a/.github/workflows/model-gate.yml
+++ b/.github/workflows/model-gate.yml
@@ -1,0 +1,29 @@
+name: model-gate
+
+# Champion/challenger gate. Blocks a PR if any model's primary metric regressed
+# vs origin/main. Make this a REQUIRED status check on `main` (Settings ->
+# Branches -> branch protection) so a worse model can never merge.
+
+on:
+  pull_request:
+    paths:
+      - "ml/**/metrics.json"
+      - "assets/ml/**"
+      - "**/*.dvc"
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # need full history to read origin/main
+
+      - run: git fetch origin main
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Compare candidate vs champion
+        run: python ml/ci/gate.py

--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -1,0 +1,60 @@
+name: train
+
+# Train on the self-hosted "staging" machine, pull data from DagsHub via DVC
+# (NOT Kaggle), log metrics to DagsHub MLflow, push artifacts, and open a
+# candidate PR. The model only ships if model-gate.yml passes on that PR.
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: "DVC stage to run (e.g. train_sleep), or 'all'"
+        default: "train_sleep"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  MLFLOW_TRACKING_URI: https://dagshub.com/hayn404/predictive-mental-health-smartwatch.mlflow
+  MLFLOW_TRACKING_USERNAME: hayn404
+  MLFLOW_TRACKING_PASSWORD: ${{ secrets.DAGSHUB_TOKEN }}
+
+jobs:
+  train:
+    runs-on: [self-hosted, gpu]        # your staging machine; falls back to any self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install deps
+        run: pip install -r ml/ci/requirements.txt
+
+      - name: Configure DVC remote auth (DagsHub)
+        run: |
+          dvc remote modify origin --local access_key_id  "${{ secrets.DAGSHUB_TOKEN }}"
+          dvc remote modify origin --local secret_access_key "${{ secrets.DAGSHUB_TOKEN }}"
+
+      - name: Pull data
+        run: dvc pull
+
+      - name: Train + eval + export (DVC pipeline)
+        run: |
+          if [ "${{ inputs.stage }}" = "all" ]; then dvc repro; else dvc repro "${{ inputs.stage }}"; fi
+
+      - name: Push artifacts to DagsHub
+        run: dvc push
+
+      - name: Open candidate PR
+        env:
+          # Use a PAT (secrets.GH_PAT) so the PR triggers model-gate.yml;
+          # PRs opened with the default GITHUB_TOKEN do NOT trigger other workflows.
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+        run: |
+          BR="model/$(date -u +%Y%m%d-%H%M%S)"
+          git config user.name  "seren-ci"
+          git config user.email "ci@seren.local"
+          git checkout -b "$BR"
+          git add -A
+          git commit -m "model: candidate from $(echo $GITHUB_SHA | cut -c1-7)" || { echo "no changes"; exit 0; }
+          git push -u origin "$BR"
+          gh pr create --base main --head "$BR" --fill --title "model: candidate $BR"

--- a/docs/MLOPS.md
+++ b/docs/MLOPS.md
@@ -1,0 +1,66 @@
+# Seren MLOps — train on GitHub Actions, version with DVC + DagsHub, ship via EAS
+
+A new model is **trained on a self-hosted GitHub Actions runner** (your staging
+machine), its data + artifacts are **versioned with DVC on DagsHub**, metrics are
+logged to **DagsHub MLflow**, and the model **ships only if it beats the deployed
+one** — then it goes to phones **over-the-air via EAS Update**.
+
+```
+ train.yml (self-hosted runner)         model-gate.yml (PR)            deploy.yml (main)
+ ──────────────────────────────         ───────────────────           ─────────────────
+ dvc pull  (data from DagsHub)   ─PR─▶  gate.py: candidate vs   ─merge─▶ dvc pull (model)
+ dvc repro (train+eval+export)          champion on main;                eas update
+ dvc push  (artifacts → DagsHub)        FAIL if any primary              (OTA → installs
+ MLflow log + open candidate PR         metric regressed                 get the model)
+```
+
+## Files
+| File | Role |
+|---|---|
+| `dvc.yaml` | Pipeline stages (train → eval → export). `dvc repro` runs them. |
+| `params.yaml` | Hyperparameters per model. |
+| `ml/<model>/metrics.json` | Held-out metrics + a `gate` block. **Git-tracked** (small) so the gate can diff it. |
+| `ml/ci/gate.py` | Champion/challenger comparison. Exit 1 = regression = PR blocked. |
+| `ml/ci/requirements.txt` | CI training deps (extends `ml/requirements.txt` + DVC + torch). |
+| `.github/workflows/train.yml` | Manual trigger → train on self-hosted runner → candidate PR. |
+| `.github/workflows/model-gate.yml` | PR check (make it **required** on `main`). |
+| `.github/workflows/deploy.yml` | On merge → `dvc pull` model → `eas update`. |
+| `scripts/setup-mlops.sh` | One-time DVC + DagsHub bootstrap (run locally). |
+
+## One-time setup
+1. `export DAGSHUB_USER=hayn404 DAGSHUB_TOKEN=<token> && bash scripts/setup-mlops.sh`
+   then commit the `.dvc` pointers.
+2. **GitHub secrets** (Settings → Secrets → Actions): `DAGSHUB_TOKEN`, `EXPO_TOKEN`,
+   and `GH_PAT` (a PAT with `repo` + `workflow` scope — needed so the auto-PR
+   triggers the gate).
+3. **Self-hosted runner:** Settings → Actions → Runners → New self-hosted runner,
+   label it `gpu`. Install Python, Node, DVC, and your CUDA stack on it once.
+4. **Branch protection:** protect `main`, require the `gate` status check.
+5. **EAS Update:** ensure `expo-updates` is configured (update URL + `production`
+   channel) so `eas update` reaches installs.
+
+## The training-script contract (wire each model once)
+A `dvc.yaml` stage calls `python ml/<model>/train.py ...`. That script must:
+- read hyperparameters from `params.yaml` (the stage's `params:` block),
+- read its data from `data/<model>/` (DVC-pulled — **not** Kaggle),
+- write the exported model into `assets/ml/<model>/`,
+- write `ml/<model>/metrics.json` with the held-out metrics **and** a `gate` block:
+  ```json
+  { "eval_set_id": "walch_v1", "walch_kappa": 0.482,
+    "gate": { "primary": "walch_kappa", "direction": "max",
+              "min_delta": 0.0, "no_regress": ["walch_weightedF1"] } }
+  ```
+`direction` is `max` for accuracy/AUC/F1/κ and `min` for MAE/loss. Changing
+`eval_set_id` blocks the gate (prevents "better" scores on an easier test set).
+
+Sleep is wired (`train_sleep` stage + `ml/sleep/metrics.json` baseline). Replicate
+the stage for stress / focus / bio-age / depression by uncommenting the templates
+in `dvc.yaml` once each `train.py` honours the contract above.
+
+## Notes / limits
+- **GitHub-hosted runners have no GPU** — the sleep deep model needs the
+  self-hosted `gpu` runner. XGBoost models run on any runner.
+- **DagsHub free tier** has storage/compute limits — version the extracted
+  feature caches (tens–hundreds of MB), not multi-GB raw dumps.
+- The deployed `.tflite`/JSON are DVC-tracked; `deploy.yml` `dvc pull`s them before
+  `eas update`. Keep them small.

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,0 +1,40 @@
+# DVC pipeline. `dvc repro` runs the stages; `dvc push` uploads data/model
+# artifacts to the DagsHub remote. Data lives in DVC (not git, not Kaggle);
+# the small per-model metrics.json stays in git so the CI gate can diff it.
+#
+# Per-stage contract for the training script:
+#   - reads its hyperparameters from params.yaml (the `params:` list below)
+#   - reads its input data from data/<model>/  (DVC-tracked, `dvc pull`ed first)
+#   - writes the exported model into assets/ml/<model>/
+#   - writes ml/<model>/metrics.json  (held-out metrics + a `gate` block)
+
+stages:
+  train_sleep:
+    cmd: python ml/sleep/train.py --params params.yaml --data data/sleep
+         --out assets/ml/sleep --metrics ml/sleep/metrics.json
+    deps:
+      - ml/sleep/train.py
+      - ml/sleep/model.py
+      - ml/sleep/dataset.py
+      - data/sleep/bidsleep_features.pkl
+      - data/sleep/walch_features.pkl
+    params:
+      - sleep
+    outs:
+      - assets/ml/sleep/sleep_stage_model.tflite
+      - assets/ml/sleep/sleep_stage_model.onnx
+    metrics:
+      - ml/sleep/metrics.json:
+          cache: false
+
+  # --- replicate per model once its train script honours the contract above ---
+  #
+  # train_stress:
+  #   cmd: python ml/stress/src/train.py --params params.yaml --data data/stress
+  #        --out assets/ml/stress --metrics ml/stress/metrics.json
+  #   deps: [ml/stress/src/train.py, data/stress]
+  #   params: [stress]
+  #   outs: [assets/ml/stress/stress_model.json]
+  #   metrics: [ml/stress/metrics.json: {cache: false}]
+  #
+  # train_focus / train_bioage / train_depression: same shape.

--- a/ml/ci/gate.py
+++ b/ml/ci/gate.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Champion/challenger model gate.
+
+Fails (exit 1) if any model's PRIMARY metric regressed versus the version on
+`origin/main`. Run in CI on pull requests that touch model metrics/assets.
+
+Contract: every trained model writes a small, git-tracked `ml/<model>/metrics.json`:
+
+    {
+      "eval_set_id": "walch_v1",          # pin the test set — changing it blocks the gate
+      "walch_kappa": 0.482,               # ...the metrics, flat keys...
+      "walch_weightedF1": 0.665,
+      "gate": {
+        "primary": "walch_kappa",         # the metric that decides promotion
+        "direction": "max",               # "max" (accuracy/AUC/F1/κ) or "min" (MAE/loss)
+        "min_delta": 0.0,                 # require at least this much improvement
+        "no_regress": ["walch_weightedF1"]# secondary metrics that may not drop
+      }
+    }
+
+The model file itself can be DVC-tracked (large); this metrics.json stays in git
+so the gate can diff it against main without pulling artifacts.
+"""
+import glob
+import json
+import subprocess
+import sys
+
+
+def champion(path: str):
+    """The metrics.json as it exists on origin/main, or None if the model is new."""
+    try:
+        blob = subprocess.check_output(
+            ["git", "show", f"origin/main:{path}"], stderr=subprocess.DEVNULL
+        )
+        return json.loads(blob)
+    except subprocess.CalledProcessError:
+        return None
+
+
+def is_better(direction: str, cand: float, champ: float, min_delta: float) -> bool:
+    if direction == "max":
+        return cand >= champ + min_delta
+    return cand <= champ - min_delta
+
+
+def main() -> int:
+    paths = sorted(glob.glob("ml/**/metrics.json", recursive=True))
+    if not paths:
+        print("no ml/**/metrics.json found — nothing to gate")
+        return 0
+
+    failed = False
+    for path in paths:
+        cand = json.load(open(path))
+        gate = cand.get("gate")
+        if not gate:
+            print(f"  -  {path}: no `gate` block, skipping")
+            continue
+
+        champ = champion(path)
+        if champ is None:
+            print(f"  OK {path}: new model (no champion on main) -> allowed")
+            continue
+
+        if cand.get("eval_set_id") != champ.get("eval_set_id"):
+            print(
+                f"  XX {path}: eval_set_id changed "
+                f"({champ.get('eval_set_id')} -> {cand.get('eval_set_id')}) "
+                "-> not comparable, blocking"
+            )
+            failed = True
+            continue
+
+        key = gate["primary"]
+        direction = gate.get("direction", "max")
+        min_delta = float(gate.get("min_delta", 0.0))
+        cv, bv = float(cand[key]), float(champ[key])
+        ok = is_better(direction, cv, bv, min_delta)
+        mark = "OK" if ok else "XX"
+        print(f"  {mark} {path}: {key} {cv:.4f} vs champion {bv:.4f} "
+              f"({direction}, min_delta {min_delta})")
+        if not ok:
+            failed = True
+
+        for k in gate.get("no_regress", []):
+            if k in cand and k in champ and float(cand[k]) < float(champ[k]):
+                print(f"       XX secondary `{k}` regressed: {cand[k]:.4f} < {champ[k]:.4f}")
+                failed = True
+
+    if failed:
+        print("\nGATE FAILED: a model regressed. The new model will NOT ship.")
+        return 1
+    print("\nGATE PASSED: all models better-or-equal. Safe to merge + deploy.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ml/ci/requirements.txt
+++ b/ml/ci/requirements.txt
@@ -1,0 +1,12 @@
+# CI training + gate deps (self-hosted runner). Extends ml/requirements.txt.
+-r ../requirements.txt
+
+# Data/experiment versioning
+dvc[s3]>=3.0
+dagshub
+
+# Sleep deep model (GPU on the self-hosted runner)
+torch
+captum
+onnx
+onnxruntime

--- a/ml/sleep/metrics.json
+++ b/ml/sleep/metrics.json
@@ -1,0 +1,15 @@
+{
+  "model": "sleep",
+  "eval_set_id": "walch_v1",
+  "walch_kappa": 0.482,
+  "walch_weightedF1": 0.665,
+  "walch_macroF1": 0.621,
+  "walch_accuracy": 0.661,
+  "walch_3class_weightedF1": 0.798,
+  "gate": {
+    "primary": "walch_kappa",
+    "direction": "max",
+    "min_delta": 0.0,
+    "no_regress": ["walch_weightedF1", "walch_macroF1"]
+  }
+}

--- a/params.yaml
+++ b/params.yaml
@@ -1,0 +1,30 @@
+# Hyperparameters consumed by the DVC pipeline (dvc.yaml). Editing a model's
+# block + `dvc repro` re-trains only that stage. Mirrors the PSO-tuned values.
+
+sleep:
+  lr: 0.00088
+  dropout: 0.20
+  lstm_hidden: 48
+  seq_len: 41
+  train_stride: 5
+  weight_decay: 1.0e-5
+  epochs: 80
+  arch: tcn_bigru_bn_v1
+
+# Fill these in as you wire each model's train stage into dvc.yaml.
+# stress:
+#   max_depth: 4
+#   n_estimators: 200
+#   learning_rate: 0.05
+# focus:
+#   max_depth: 2
+#   n_estimators: 400
+#   window_sec: 120
+# bioage:
+#   max_depth: 3
+#   n_estimators: 400
+#   learning_rate: 0.03
+# depression:
+#   max_depth: 4
+#   n_estimators: 200
+#   learning_rate: 0.05

--- a/scripts/setup-mlops.sh
+++ b/scripts/setup-mlops.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# One-time MLOps bootstrap: DVC + DagsHub. Run LOCALLY, once, with the training
+# data present on disk. Afterwards, training/gating/deploy run in GitHub Actions.
+#
+#   export DAGSHUB_USER=hayn404
+#   export DAGSHUB_TOKEN=<your dagshub token>
+#   bash scripts/setup-mlops.sh
+set -euo pipefail
+
+: "${DAGSHUB_USER:?set DAGSHUB_USER}"
+: "${DAGSHUB_TOKEN:?set DAGSHUB_TOKEN}"
+REPO="predictive-mental-health-smartwatch"
+
+pip install "dvc[s3]" dagshub
+
+# init DVC (no-op if already initialised)
+dvc init || true
+
+# DagsHub S3-compatible DVC remote
+dvc remote add -d origin s3://dvc 2>/dev/null || true
+dvc remote modify origin endpointurl "https://dagshub.com/${DAGSHUB_USER}/${REPO}.s3"
+dvc remote modify origin --local access_key_id     "${DAGSHUB_TOKEN}"
+dvc remote modify origin --local secret_access_key "${DAGSHUB_TOKEN}"
+
+# Track the training DATA (edit these paths to match your local caches).
+# These are the feature caches that used to live as Kaggle datasets.
+for f in \
+  data/sleep/bidsleep_features.pkl \
+  data/sleep/walch_features.pkl \
+  data/depresjon \
+  data/cogwear ; do
+  [ -e "$f" ] && dvc add "$f" || echo "skip (missing): $f"
+done
+
+git add .dvc .dvcignore dvc.yaml params.yaml 2>/dev/null || true
+git add data/*.dvc data/**/*.dvc data/.gitignore 2>/dev/null || true
+
+dvc push   # upload data to DagsHub
+
+cat <<'EOF'
+
+Done. Next:
+  1. git commit -m "chore: track training data with DVC on DagsHub" && git push
+  2. Add GitHub secrets: DAGSHUB_TOKEN, EXPO_TOKEN, GH_PAT (repo+workflow scope)
+  3. Register your staging machine: Settings -> Actions -> Runners -> New self-hosted runner
+     (label it `gpu` for the sleep model)
+  4. Protect main: require the `gate` status check before merge
+EOF


### PR DESCRIPTION
Adds the CI/CD that **trains on a self-hosted staging runner, versions data/models with DVC on DagsHub (no Kaggle), gates on metrics, and ships the winner over-the-air via EAS Update.**

**Flow:** `train.yml` (self-hosted, `dvc pull` → `dvc repro` → `dvc push` → MLflow → candidate PR) → `model-gate.yml` (blocks if a primary metric regressed vs main) → `deploy.yml` (on merge: `dvc pull` model → `eas update`).

- `dvc.yaml` + `params.yaml` — pipeline (sleep wired; other models templated)
- `ml/ci/gate.py` — champion/challenger gate (pins `eval_set_id` to prevent easier-test-set gaming)
- `ml/sleep/metrics.json` — baseline champion + gate block
- `scripts/setup-mlops.sh` + `docs/MLOPS.md` — one-time DVC/DagsHub bootstrap + guide

Validated: `gate.py` compiles/runs, all JSON/YAML parse. Manual steps remain (secrets, self-hosted runner, branch protection) — see docs/MLOPS.md.