### PR TITLE
ci(stress): wire stress model into DVC/gate pipeline

### DIFF
--- a/docs/MLOPS.md
+++ b/docs/MLOPS.md
@@ -53,9 +53,25 @@ A `dvc.yaml` stage calls `python ml/<model>/train.py ...`. That script must:
 `direction` is `max` for accuracy/AUC/F1/κ and `min` for MAE/loss. Changing
 `eval_set_id` blocks the gate (prevents "better" scores on an easier test set).
 
-Sleep is wired (`train_sleep` stage + `ml/sleep/metrics.json` baseline). Replicate
-the stage for stress / focus / bio-age / depression by uncommenting the templates
-in `dvc.yaml` once each `train.py` honours the contract above.
+**Sleep** and **stress** are wired (`train_sleep` / `train_stress` stages +
+`ml/sleep/metrics.json` / `ml/stress/metrics.json` baselines). Replicate the stage
+for focus / bio-age / depression by copying `train_stress` in `dvc.yaml` once each
+`train.py` honours the contract above.
+
+### Data sources (download once → `data/<model>/` → DVC → DagsHub)
+After the first `dvc add` + `dvc push`, CI pulls everything from DagsHub — Kaggle
+is never touched again.
+
+| Model | `data/<model>/` holds | Source |
+|---|---|---|
+| sleep | `bidsleep_features.pkl`, `walch_features.pkl` | Kaggle `dohahemdan17/seren-sleep-cache` |
+| stress | WESAD (held-out test), Stress-Predict/SIPD, PhysioStress | Kaggle `orvile/wesad-...`, `dohahemdan17/stress-predict-dataset`, `dohahemdan17/wearable-dataset` |
+
+### Gate metrics (primary)
+| Model | primary | direction | eval_set_id |
+|---|---|---|---|
+| sleep | `walch_kappa` | max | `walch_v1` |
+| stress | `heldout_auc` (SIPD→WESAD) | max | `wesad_v1` |
 
 ## Notes / limits
 - **GitHub-hosted runners have no GPU** — the sleep deep model needs the

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -27,14 +27,21 @@ stages:
       - ml/sleep/metrics.json:
           cache: false
 
+  train_stress:
+    cmd: python ml/stress/src/train.py --params params.yaml --data data/stress
+         --out assets/ml/stress --metrics ml/stress/metrics.json
+    deps:
+      - ml/stress/src/train.py
+      - ml/stress/src/features.py
+      - ml/stress/src/preprocessing.py
+      - data/stress
+    params:
+      - stress
+    outs:
+      - assets/ml/stress/stress_model.json
+    metrics:
+      - ml/stress/metrics.json:
+          cache: false
+
   # --- replicate per model once its train script honours the contract above ---
-  #
-  # train_stress:
-  #   cmd: python ml/stress/src/train.py --params params.yaml --data data/stress
-  #        --out assets/ml/stress --metrics ml/stress/metrics.json
-  #   deps: [ml/stress/src/train.py, data/stress]
-  #   params: [stress]
-  #   outs: [assets/ml/stress/stress_model.json]
-  #   metrics: [ml/stress/metrics.json: {cache: false}]
-  #
-  # train_focus / train_bioage / train_depression: same shape.
+  # train_focus / train_bioage / train_depression: same shape as train_stress.

--- a/ml/ci/gate.py
+++ b/ml/ci/gate.py
@@ -30,9 +30,10 @@ import sys
 
 def champion(path: str):
     """The metrics.json as it exists on origin/main, or None if the model is new."""
+    git_path = path.replace("\\", "/")  # git wants forward slashes (Windows glob gives \)
     try:
         blob = subprocess.check_output(
-            ["git", "show", f"origin/main:{path}"], stderr=subprocess.DEVNULL
+            ["git", "show", f"origin/main:{git_path}"], stderr=subprocess.DEVNULL
         )
         return json.loads(blob)
     except subprocess.CalledProcessError:

--- a/ml/stress/metrics.json
+++ b/ml/stress/metrics.json
@@ -1,0 +1,15 @@
+{
+  "model": "stress",
+  "eval_set_id": "wesad_v1",
+  "heldout_auc": 0.858,
+  "heldout_dataset": "WESAD",
+  "train_datasets": ["SIPD", "PhysioStress"],
+  "cv_auc_roc_loso": 0.657,
+  "n_features": 14,
+  "gate": {
+    "primary": "heldout_auc",
+    "direction": "max",
+    "min_delta": 0.0,
+    "no_regress": ["cv_auc_roc_loso"]
+  }
+}

--- a/params.yaml
+++ b/params.yaml
@@ -11,11 +11,21 @@ sleep:
   epochs: 80
   arch: tcn_bigru_bn_v1
 
+stress:
+  # XGBoost (mirrors ml/stress/config/default.yaml)
+  n_estimators: 200
+  max_depth: 6
+  learning_rate: 0.1
+  subsample: 0.8
+  colsample_bytree: 0.8
+  window_sec: 300
+  label_purity: 0.8
+  cv_strategy: loso          # leave-one-subject-out for the dev metric
+  train_on: SIPD             # dev datasets (SIPD + PhysioStress fusion)
+  final_test: WESAD          # held-out cross-dataset test
+  normalization: per_subject
+
 # Fill these in as you wire each model's train stage into dvc.yaml.
-# stress:
-#   max_depth: 4
-#   n_estimators: 200
-#   learning_rate: 0.05
 # focus:
 #   max_depth: 2
 #   n_estimators: 400

--- a/scripts/setup-mlops.sh
+++ b/scripts/setup-mlops.sh
@@ -27,10 +27,17 @@ dvc remote modify origin --local secret_access_key "${DAGSHUB_TOKEN}"
 for f in \
   data/sleep/bidsleep_features.pkl \
   data/sleep/walch_features.pkl \
+  data/stress \
   data/depresjon \
   data/cogwear ; do
   [ -e "$f" ] && dvc add "$f" || echo "skip (missing): $f"
 done
+
+# data/stress/ should hold the three source datasets (download once, then this
+# tracks them on DagsHub so CI never touches Kaggle again):
+#   - WESAD            (kaggle: orvile/wesad-wearable-stress-affect-detection-dataset) -> held-out test
+#   - Stress-Predict   (kaggle: dohahemdan17/stress-predict-dataset)                   -> SIPD (train)
+#   - PhysioStress     (kaggle: dohahemdan17/wearable-dataset)                          -> train (fusion)
 
 git add .dvc .dvcignore dvc.yaml params.yaml 2>/dev/null || true
 git add data/*.dvc data/**/*.dvc data/.gitignore 2>/dev/null || true


### PR DESCRIPTION
Adds the stress model to the same CI/CD as sleep.

- `dvc.yaml`: **train_stress** stage (`ml/stress/src/train.py`, `data/stress` → `assets/ml/stress/stress_model.json`)
- `params.yaml`: stress XGBoost block (mirrors `config/default.yaml`; SIPD + PhysioStress → WESAD held-out)
- `ml/stress/metrics.json`: champion baseline — held-out **SIPD→WESAD AUC 0.858**; gate `primary=heldout_auc`, pins `eval_set_id=wesad_v1`
- `setup-mlops.sh`: track `data/stress` (WESAD + Stress-Predict/SIPD + PhysioStress — the 3 Kaggle source datasets, versioned to DagsHub once)
- `docs/MLOPS.md`: data-source + gate-metric tables
- `gate.py`: cross-platform path fix (Windows backslash → git forward-slash)

Validated: gate runs over both models (sleep vs champion, stress new → allowed); all YAML/JSON parse.