### PR TITLE
feat(onboarding): collect age + actually request runtime permissions

### DIFF
--- a/app/onboarding/_layout.tsx
+++ b/app/onboarding/_layout.tsx
@@ -4,6 +4,7 @@ export default function OnboardingLayout() {
     return (
         <Stack screenOptions={{ headerShown: false, animation: 'fade' }}>
             <Stack.Screen name="welcome" />
+            <Stack.Screen name="profile" />
             <Stack.Screen name="sync" />
             <Stack.Screen name="privacy" />
         </Stack>

--- a/app/onboarding/privacy.tsx
+++ b/app/onboarding/privacy.tsx
@@ -12,16 +12,24 @@ import { MaterialIcons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Colors, FontSize, FontWeight, Spacing, Radius } from '@/constants/theme';
 import { Image } from 'expo-image';
+import { Audio } from 'expo-av';
 import { requestNotificationPermissions } from '@/utils/notifications';
+import { useWellness } from '@/hooks/useWellness';
 
 export default function PrivacyScreen() {
     const router = useRouter();
     const insets = useSafeAreaInsets();
+    const { requestHealthConnectPermissions } = useWellness();
     const [onDevice, setOnDevice] = useState(true);
+    const [busy, setBusy] = useState(false);
 
     const handleFinish = async () => {
-        // Request notification permissions explicitly before continuing
-        await requestNotificationPermissions();
+        // Actually request the runtime permissions the models need, in sequence.
+        setBusy(true);
+        try { await requestNotificationPermissions(); } catch { /* user can grant later */ }
+        try { await requestHealthConnectPermissions(); } catch { /* HC may be absent */ }
+        try { await Audio.requestPermissionsAsync(); } catch { /* mic for voice check-ins */ }
+        setBusy(false);
         router.replace('/(tabs)');
     };
 
@@ -108,11 +116,12 @@ export default function PrivacyScreen() {
                 </View>
 
                 <TouchableOpacity
-                    style={styles.startButton}
+                    style={[styles.startButton, busy && { opacity: 0.6 }]}
                     onPress={handleFinish}
+                    disabled={busy}
                 >
                     <Text style={styles.startButtonText}>
-                        Start Your Journey
+                        {busy ? 'Requesting permissions…' : 'Start Your Journey'}
                     </Text>
                     <MaterialIcons name="arrow-forward" size={20} color={Colors.warmWhite} />
                 </TouchableOpacity>

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -1,0 +1,133 @@
+import React, { useState } from 'react';
+import {
+    View,
+    Text,
+    StyleSheet,
+    TouchableOpacity,
+    ScrollView,
+    TextInput,
+    KeyboardAvoidingView,
+    Platform,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { MaterialIcons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Colors, FontSize, FontWeight, Spacing, Radius } from '@/constants/theme';
+import { Image } from 'expo-image';
+import { useWellness } from '@/hooks/useWellness';
+
+export default function ProfileScreen() {
+    const router = useRouter();
+    const insets = useSafeAreaInsets();
+    const { setChronologicalAge } = useWellness();
+    const [age, setAge] = useState('');
+    const [error, setError] = useState('');
+
+    const handleNext = () => {
+        const a = parseInt(age, 10);
+        if (isNaN(a) || a < 5 || a > 120) {
+            setError('Please enter a valid age (5–120).');
+            return;
+        }
+        setChronologicalAge(a);            // persisted on-device (chronological_age)
+        router.push('/onboarding/sync');
+    };
+
+    return (
+        <View style={styles.container}>
+            <KeyboardAvoidingView
+                behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+                style={{ flex: 1 }}
+            >
+                <ScrollView
+                    showsVerticalScrollIndicator={false}
+                    contentContainerStyle={{ paddingTop: insets.top + Spacing.xl, paddingBottom: insets.bottom + Spacing.xl }}
+                >
+                    <View style={styles.header}>
+                        <View style={styles.titleRow}>
+                            <View style={styles.appIconContainer}>
+                                <Image source={require('@/assets/images/seren-brain.png')} style={styles.appIcon} />
+                            </View>
+                            <Text style={styles.setupTitle}>About You</Text>
+                        </View>
+
+                        <View style={styles.progressRow}>
+                            <Text style={styles.stepText}>STEP 1 OF 3</Text>
+                            <Text style={styles.stepSubText}>Your Profile</Text>
+                        </View>
+                        <View style={styles.progressBarBg}>
+                            <View style={[styles.progressBarFill, { width: '33%' }]} />
+                        </View>
+
+                        <Text style={styles.heading}>A little about you.</Text>
+                        <Text style={styles.subtitle}>
+                            Your age personalizes your physiological &quot;heart age&quot; and the
+                            age-gap insight. It stays on your device.
+                        </Text>
+                    </View>
+
+                    <View style={styles.field}>
+                        <Text style={styles.label}>Your age</Text>
+                        <TextInput
+                            style={styles.input}
+                            value={age}
+                            onChangeText={(t) => { setAge(t.replace(/[^0-9]/g, '')); setError(''); }}
+                            keyboardType="number-pad"
+                            placeholder="e.g. 25"
+                            placeholderTextColor={Colors.textMuted}
+                            maxLength={3}
+                            returnKeyType="done"
+                            onSubmitEditing={handleNext}
+                        />
+                        {error ? <Text style={styles.error}>{error}</Text> : null}
+                    </View>
+
+                    <TouchableOpacity style={styles.startButton} onPress={handleNext}>
+                        <Text style={styles.startButtonText}>Continue</Text>
+                        <MaterialIcons name="arrow-forward" size={20} color={Colors.warmWhite} />
+                    </TouchableOpacity>
+                </ScrollView>
+            </KeyboardAvoidingView>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: { flex: 1, backgroundColor: Colors.cream },
+    header: { marginBottom: Spacing.xl, paddingHorizontal: Spacing.xl },
+    titleRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: Spacing.lg },
+    appIconContainer: { width: 32, height: 32, borderRadius: Radius.md, overflow: 'hidden', backgroundColor: Colors.warmWhite },
+    appIcon: { width: '100%', height: '100%', resizeMode: 'contain' },
+    setupTitle: { fontSize: FontSize.lg, fontWeight: FontWeight.bold, color: Colors.textPrimary },
+    progressRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: Spacing.sm },
+    stepText: { fontSize: FontSize.xs, color: Colors.violet, fontWeight: '700', letterSpacing: 1.2 },
+    stepSubText: { fontSize: FontSize.xs, color: Colors.textSecondary, fontWeight: '500' },
+    progressBarBg: { height: 4, backgroundColor: Colors.violetMuted, borderRadius: Radius.full, marginBottom: Spacing.xl },
+    progressBarFill: { height: 4, backgroundColor: Colors.violet, borderRadius: Radius.full },
+    heading: { fontSize: FontSize.xxl, fontWeight: FontWeight.bold, color: Colors.textPrimary, marginBottom: Spacing.xs },
+    subtitle: { fontSize: FontSize.md, color: Colors.textSecondary, lineHeight: 24 },
+    field: { paddingHorizontal: Spacing.xl, marginBottom: Spacing.xl },
+    label: { fontSize: FontSize.sm, fontWeight: FontWeight.semibold, color: Colors.textPrimary, marginBottom: Spacing.sm },
+    input: {
+        backgroundColor: Colors.warmWhite,
+        borderRadius: Radius.md,
+        paddingHorizontal: Spacing.lg,
+        paddingVertical: Spacing.md,
+        fontSize: FontSize.lg,
+        color: Colors.textPrimary,
+        borderWidth: 1,
+        borderColor: Colors.warmGray300,
+    },
+    error: { color: Colors.error, fontSize: FontSize.sm, marginTop: Spacing.sm },
+    startButton: {
+        flexDirection: 'row',
+        backgroundColor: Colors.sageGreen,
+        paddingVertical: Spacing.lg,
+        marginHorizontal: Spacing.xl,
+        borderRadius: Radius.md,
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+    },
+    startButtonText: { fontSize: FontSize.md, fontWeight: FontWeight.bold, color: Colors.warmWhite },
+});

--- a/app/onboarding/welcome.tsx
+++ b/app/onboarding/welcome.tsx
@@ -60,7 +60,7 @@ export default function WelcomeScreen() {
             setCurrentSlide(next);
             scrollRef.current?.scrollTo({ x: next * width, animated: true });
         } else {
-            router.push('/onboarding/sync');
+            router.push('/onboarding/profile' as any);
         }
     };
 
@@ -143,7 +143,7 @@ export default function WelcomeScreen() {
                 </TouchableOpacity>
 
                 {currentSlide < slides.length - 1 ? (
-                    <TouchableOpacity onPress={() => router.push('/onboarding/sync')} style={styles.skipBtn}>
+                    <TouchableOpacity onPress={() => router.push('/onboarding/profile' as any)} style={styles.skipBtn}>
                         <Text style={styles.skipText}>Skip introduction</Text>
                     </TouchableOpacity>
                 ) : <View style={styles.skipBtnPlaceholder} />}


### PR DESCRIPTION
Fixes two real gaps found on the install build:

1. **No permissions were being requested** — the privacy step showed permission cards with check-marks but only requested *notifications*. Now `handleFinish` requests **notifications + Health Connect (HR/HRV/sleep/steps) + microphone** in sequence.
2. **Age wasn't collected at sign-up** — added an onboarding **profile** step (welcome → profile → sync → privacy) that asks the user's age and persists it via `setChronologicalAge` (powers the bio-age gap). Previously age defaulted to 25 and was only editable in Settings.

tsc clean, 185/185 jest pass.