### PR TITLE
fix(sleep): correct architecture label BiLSTM -> BiGRU

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ depression screening, and voice-emotion — plus PHQ-9 / GAD-7 self-report tools
   EpochAggregator → feature batches                                 ▼
   (sleep 48 B/epoch; env light+GPS)                          on-device models
                                                               ├─ stress   (XGBoost / HRV)
-                                                              ├─ sleep    (TCN+BiLSTM / TFLite)
+                                                              ├─ sleep    (TCN+BiGRU / TFLite)
                                                               ├─ focus    (XGBoost / HRV)
                                                               ├─ bio-age  (XGBoost / HRV)
                                                               ├─ depression (XGBoost / actigraphy)
@@ -35,7 +35,7 @@ depression screening, and voice-emotion — plus PHQ-9 / GAD-7 self-report tools
 | Model | Task | Data (train → test) | Headline | Runtime |
 |---|---|---|---|---|
 | **Stress** | binary stress | SIPD + PhysioStress → WESAD (cross-dataset) | AUC **0.86** | XGBoost (TS tree) |
-| **Sleep** | 4-class staging (Wake/Light/Deep/REM) | BIDSleep → Walch (zero-shot) | κ **0.48** · wF1 0.665 · Deep recall 0.78 · 3-class wF1 0.80 | TCN+BiLSTM (TFLite) |
+| **Sleep** | 4-class staging (Wake/Light/Deep/REM) | BIDSleep → Walch (zero-shot) | κ **0.48** · wF1 0.665 · Deep recall 0.78 · 3-class wF1 0.80 | TCN+BiGRU (TFLite) |
 | **Focus** | cognitive engagement | CogWear (LOSO) → MAUS (external) | AUC **0.82** (0.95 sustained) | XGBoost (TS tree) |
 | **Bio-age** | physiological age + age-gap | Autonomic Aging → Fantasia | MAE **7.6 yr** · young-vs-old AUC 0.94 | XGBoost (TS tree) |
 | **Depression** | screening | Depresjon (actigraphy) | acc **0.92** · ROC-AUC 0.97 | XGBoost (TS tree) |

--- a/assets/ml/sleep/sleep_model_metadata.json
+++ b/assets/ml/sleep/sleep_model_metadata.json
@@ -1,6 +1,6 @@
 {
   "version": "3.2.0",
-  "modelType": "tcn_bilstm_seq2seq_hr_actigraphy",
+  "modelType": "tcn_bigru_seq2seq_hr_actigraphy",
   "task": "sleep_stage_classification_4class",
   "trainData": "BIDSleep (Apple Watch)",
   "testData": "Walch/Sleep-Accel (held-out)",

--- a/ml/sleep/convert_onnx_to_tflite.py
+++ b/ml/sleep/convert_onnx_to_tflite.py
@@ -8,7 +8,7 @@ Run:  python ml/sleep/convert_onnx_to_tflite.py
 Out:  assets/ml/sleep/sleep_stage_model.tflite  (+ parity report vs ONNX)
 
 Input is pinned to a static [1, 41, 11] (batch 1, SEQ_LEN 41, 11 features) which is
-exactly how the app windows the night -> robust TFLite conversion of the BiLSTM.
+exactly how the app windows the night -> robust TFLite conversion of the BiGRU.
 
 NOTE: feature count changed 12 -> 11 after XAI confirmed `immobility_frac` is dead
 weight. If you see a shape-mismatch error, you're converting an old (pre-prune) ONNX;


### PR DESCRIPTION
The deployed sleep model is **TCN + BiGRU** (`nn.GRU`, arch tag `tcn_bigru_bn_v1`). Corrects mislabels in README, `sleep_model_metadata.json` (`modelType`), and the TFLite converter docstring. Left the intentional 'BiLSTM' references in `sleepStageModel.ts` and the notebook builder — those describe the *abandoned* LayerNorm+BiLSTM variant.